### PR TITLE
Fix up deploy to use last successful commit 

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -79,12 +79,42 @@ jobs:
           path: scripts
           ref: main
 
-      - uses: nrwl/nx-set-shas@v3
-        id: last_successful_commit_push
+      - name: Get last successful workflow_dispatch run
+        id: last_successful_workflow_dispatch_run
+        uses: actions/github-script@v7
         with:
-          main-branch-name: ${{ needs.set-state.outputs.branch_short_ref }}
-          last-successful-event: 'workflow_dispatch' # This is the event that triggered the last successful workflow run.
-          workflow-id: ${{ needs.set-state.outputs.deploy_prod == 'true' && 'deploy.yml' || 'stage.yml' }}
+          script: |
+            const { owner, repo } = context.repo;
+            const branch = needs.set-state.outputs.branch_short_ref;
+            const workflowId = ${{ needs.set-state.outputs.deploy_prod == 'true' && 'deploy.yml' || 'stage.yml' }}
+
+            const workflowRuns = await github.rest.actions.listWorkflowRuns({
+              owner,
+              repo,
+              workflow_id: workflowId,
+              branch: branch,
+              event: 'workflow_dispatch',
+              status: 'success',
+              per_page: 1, // Only need the latest one
+            });
+
+            if (workflowRuns.data.workflow_runs.length > 0) {
+              const lastSuccessfulRun = workflowRuns.data.workflow_runs[0];
+              console.log(`Last successful workflow_dispatch run on branch '${branch}':`);
+              console.log(`ID: ${lastSuccessfulRun.id}`);
+              console.log(`Commit SHA: ${lastSuccessfulRun.head_sha}`);
+              console.log(`Run URL: ${lastSuccessfulRun.html_url}`);
+              core.setOutput('base', lastSuccessfulRun.head_sha);
+            } else {
+              console.log(`No successful workflow_dispatch runs found on branch '${branch}' for workflow '${workflowId}'.`);
+              core.setOutput('base', '');
+            }
+      # - uses: nrwl/nx-set-shas@v3
+      #   id: last_successful_commit_push
+      #   with:
+      #     main-branch-name: ${{ needs.set-state.outputs.branch_short_ref }}
+      #     last-successful-event: 'workflow_dispatch' # This is the event that triggered the last successful workflow run.
+      #     workflow-id: ${{ needs.set-state.outputs.deploy_prod == 'true' && 'deploy.yml' || 'stage.yml' }}
 
       - name: Get changed files in the src/pages folder
         if: needs.set-state.outputs.deploy_All == 'false'
@@ -95,7 +125,7 @@ jobs:
           escape_json: false
           files: |
             src/pages/**
-          base_sha: ${{ needs.set-state.outputs.base_Sha || steps.last_successful_commit_push.outputs.base }}
+          base_sha: ${{ needs.set-state.outputs.base_Sha || steps.last_successful_workflow_dispatch_run.outputs.base }}
 
       - name: Get all files from src/pages folder
         if: needs.set-state.outputs.deploy_All == 'true'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,7 +77,7 @@ jobs:
         with:
           repository: AdobeDocs/adp-devsite-scripts
           path: scripts
-          ref: main
+          ref: deploy-fail
 
       - name: Get last successful workflow_dispatch run
         id: last_successful_workflow_dispatch_run

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -79,15 +79,11 @@ jobs:
           path: scripts
           ref: main
 
-      - name: Get branch name
-        id: branch-name
-        uses: tj-actions/branch-names@v6
-
       - uses: nrwl/nx-set-shas@v3
         id: last_successful_commit_push
         with:
-          main-branch-name: ${{ steps.branch-name.outputs.current_branch }} # Get the last successful commit for the current branch.
-          workflow-id: 'deploy.yml'
+          main-branch-name: ${{ steps.get_branch.outputs.branch }} # Get the last successful commit for the current branch.
+          workflow-id: ${{ needs.set-state.outputs.deploy_prod == 'true' && 'deploy.yml' || 'staging.yml' }}
 
       - name: Get changed files in the src/pages folder
         if: needs.set-state.outputs.deploy_All == 'false'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -88,7 +88,7 @@ jobs:
           escape_json: false
           files: |
             src/pages/**
-          base_sha: ${{ needs.set-state.outputs.base_Sha }}
+          base_sha: ${{ needs.set-state.outputs.base_Sha || steps.last_successful_commit_push.outputs.base }}
 
       - name: Get all files from src/pages folder
         if: needs.set-state.outputs.deploy_All == 'true'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -82,7 +82,8 @@ jobs:
       - uses: nrwl/nx-set-shas@v3
         id: last_successful_commit_push
         with:
-          main-branch-name: ${{ needs.set-state.outputs.branch_short_ref }} # Get the last successful commit for the current branch.
+          main-branch-name: ${{ needs.set-state.outputs.branch_short_ref }}
+          last-successful-event: 'workflow_dispatch' # This is the event that triggered the last successful workflow run.
           workflow-id: ${{ needs.set-state.outputs.deploy_prod == 'true' && 'deploy.yml' || 'stage.yml' }}
 
       - name: Get changed files in the src/pages folder

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -79,6 +79,16 @@ jobs:
           path: scripts
           ref: main
 
+      - name: Get branch name
+        id: branch-name
+        uses: tj-actions/branch-names@v6
+
+      - uses: nrwl/nx-set-shas@v3
+        id: last_successful_commit_push
+        with:
+          main-branch-name: ${{ steps.branch-name.outputs.current_branch }} # Get the last successful commit for the current branch.
+          workflow-id: 'deploy.yml'
+
       - name: Get changed files in the src/pages folder
         if: needs.set-state.outputs.deploy_All == 'false'
         id: changed-files-specific

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -85,8 +85,8 @@ jobs:
         with:
           script: |
             const { owner, repo } = context.repo;
-            const branch = needs.set-state.outputs.branch_short_ref;
-            const workflowId = ${{ needs.set-state.outputs.deploy_prod == 'true' && 'deploy.yml' || 'stage.yml' }}
+            const branch = '${{ needs.set-state.outputs.branch_short_ref }}';
+            const workflowId = '${{ needs.set-state.outputs.deploy_prod == 'true' && 'deploy.yml' || 'stage.yml' }}';
 
             const workflowRuns = await github.rest.actions.listWorkflowRuns({
               owner,

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           repository: AdobeDocs/adp-devsite-scripts
           path: scripts
-          ref: main
+          ref: deploy-fail
 
       - name: Get path prefix
         uses: actions/github-script@v7

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,8 +21,8 @@ jobs:
       branch_short_ref: ${{ steps.get_branch.outputs.branch }}
       deploy_stage: ${{ contains(inputs.env, 'stage') }}
       deploy_prod: ${{ contains(inputs.env, 'prod') }}
-      base_Sha: ${{ github.event.inputs.baseSha }}
-      deploy_All: ${{ github.event.inputs.deployAll }}
+      base_Sha: ${{ inputs.baseSha }}
+      deploy_All: ${{ inputs.deployAll }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -82,7 +82,7 @@ jobs:
       - uses: nrwl/nx-set-shas@v3
         id: last_successful_commit_push
         with:
-          main-branch-name: ${{ steps.get_branch.outputs.branch }} # Get the last successful commit for the current branch.
+          main-branch-name: ${{ needs.set-state.outputs.branch_short_ref }} # Get the last successful commit for the current branch.
           workflow-id: ${{ needs.set-state.outputs.deploy_prod == 'true' && 'deploy.yml' || 'stage.yml' }}
 
       - name: Get changed files in the src/pages folder

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -83,7 +83,7 @@ jobs:
         id: last_successful_commit_push
         with:
           main-branch-name: ${{ steps.get_branch.outputs.branch }} # Get the last successful commit for the current branch.
-          workflow-id: ${{ needs.set-state.outputs.deploy_prod == 'true' && 'deploy.yml' || 'staging.yml' }}
+          workflow-id: ${{ needs.set-state.outputs.deploy_prod == 'true' && 'deploy.yml' || 'stage.yml' }}
 
       - name: Get changed files in the src/pages folder
         if: needs.set-state.outputs.deploy_All == 'false'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           repository: AdobeDocs/adp-devsite-scripts
           path: scripts
-          ref: deploy-fail
+          ref: main
 
       - name: Get path prefix
         uses: actions/github-script@v7
@@ -77,7 +77,7 @@ jobs:
         with:
           repository: AdobeDocs/adp-devsite-scripts
           path: scripts
-          ref: deploy-fail
+          ref: main
 
       - name: Get last successful workflow_dispatch run
         id: last_successful_workflow_dispatch_run


### PR DESCRIPTION
This PR adds the ability to deploy files from the last successful commit from the workflow. It should also figure out all the files necessary to deploy.