### PR TITLE
fix: wrap a try/catch in getting the last sucessful deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -88,25 +88,31 @@ jobs:
             const branch = '${{ needs.set-state.outputs.branch_short_ref }}';
             const workflowId = '${{ needs.set-state.outputs.deploy_prod == 'true' && 'deploy.yml' || 'stage.yml' }}';
 
-            const workflowRuns = await github.rest.actions.listWorkflowRuns({
-              owner,
-              repo,
-              workflow_id: workflowId,
-              branch: branch,
-              event: 'workflow_dispatch',
-              status: 'success',
-              per_page: 1, // Only need the latest one
-            });
+            try {
+              const workflowRuns = await github.rest.actions.listWorkflowRuns({
+                owner,
+                repo,
+                workflow_id: workflowId,
+                branch: branch,
+                event: 'workflow_dispatch',
+                status: 'success',
+                per_page: 1, // Only need the latest one
+              });
 
-            if (workflowRuns.data.workflow_runs.length > 0) {
-              const lastSuccessfulRun = workflowRuns.data.workflow_runs[0];
-              console.log(`Last successful workflow_dispatch run on branch '${branch}':`);
-              console.log(`ID: ${lastSuccessfulRun.id}`);
-              console.log(`Commit SHA: ${lastSuccessfulRun.head_sha}`);
-              console.log(`Run URL: ${lastSuccessfulRun.html_url}`);
-              core.setOutput('base', lastSuccessfulRun.head_sha);
-            } else {
-              console.log(`No successful workflow_dispatch runs found on branch '${branch}' for workflow '${workflowId}'.`);
+              if (workflowRuns.data.workflow_runs.length > 0) {
+                const lastSuccessfulRun = workflowRuns.data.workflow_runs[0];
+                console.log(`Last successful workflow_dispatch run on branch '${branch}':`);
+                console.log(`ID: ${lastSuccessfulRun.id}`);
+                console.log(`Commit SHA: ${lastSuccessfulRun.head_sha}`);
+                console.log(`Run URL: ${lastSuccessfulRun.html_url}`);
+                core.setOutput('base', lastSuccessfulRun.head_sha);
+              } else {
+                console.log(`No successful workflow_dispatch runs found on branch '${branch}' for workflow '${workflowId}'.`);
+                core.setOutput('base', '');
+              }
+            } catch (error) {
+              console.log(`Error fetching workflow runs: ${error.message}`);
+              console.log(`Workflow '${workflowId}' may not exist in this repository. Defaulting base to empty string.`);
               core.setOutput('base', '');
             }
       # - uses: nrwl/nx-set-shas@v3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -115,12 +115,6 @@ jobs:
               console.log(`Workflow '${workflowId}' may not exist in this repository. Defaulting base to empty string.`);
               core.setOutput('base', '');
             }
-      # - uses: nrwl/nx-set-shas@v3
-      #   id: last_successful_commit_push
-      #   with:
-      #     main-branch-name: ${{ needs.set-state.outputs.branch_short_ref }}
-      #     last-successful-event: 'workflow_dispatch' # This is the event that triggered the last successful workflow run.
-      #     workflow-id: ${{ needs.set-state.outputs.deploy_prod == 'true' && 'deploy.yml' || 'stage.yml' }}
 
       - name: Get changed files in the src/pages folder
         if: needs.set-state.outputs.deploy_All == 'false'


### PR DESCRIPTION
This change wraps getting the last successful deploy in a try catch so it doesn't error out when it can't find it like:
```
data: {
      message: 'Not Found',
      documentation_url: 'https://docs.github.com/rest/actions/workflow-runs#list-workflow-runs-for-a-workflow',
      status: '404'
    }
```