### PR TITLE
feat: build site metadata during deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -72,6 +72,32 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Checkout Utils Repo
+        uses: actions/checkout@v4
+        with:
+          repository: AdobeDocs/adp-devsite-utils
+          path: utils
+          ref: build-site-metadata
+
+      - name: Install utils dependencies
+        run: |
+          cd utils
+          npm install
+
+      - name: Build site metadata
+        run: node utils/bin/buildSiteMetadata.js -v
+
+      - name: Commit site metadata if changed
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add src/pages/adp-site-metadata.json
+          if ! git diff --cached --quiet; then
+            git commit -m "chore: update site metadata [skip ci]"
+            git pull --rebase
+            git push
+          fi
+
       - name: Checkout Scripts Repo
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,7 +77,7 @@ jobs:
         with:
           repository: AdobeDocs/adp-devsite-utils
           path: utils
-          ref: build-site-metadata
+          ref: main
 
       - name: Install utils dependencies
         run: |


### PR DESCRIPTION
## Description
Generate and commit `adp-site-metadata.json`, with 
- `git pull --rebase` to prevent push rejections when the remote branch has advanced since checkout
- [skip ci] to prevent triggering an auto-deploy on commit

## Ticket
https://jira.corp.adobe.com/browse/DEVSITE-2157

## Test
1. Set up test workflow: https://github.com/AdobeDocs/adp-devsite-github-actions-test/blob/main/.github/workflows/deploy-2157.yml#L29
2. Deploy: https://github.com/AdobeDocs/adp-devsite-github-actions-test/actions/runs/22233457148/workflow
3. Notice commit: https://github.com/AdobeDocs/adp-devsite-github-actions-test/commit/e99674c81d262b2ff6c5b66a4201777681d17b4b
4. Notice it didn't trigger another deploy from that commit
5. Notice site metadata got included as part of changed files (passed to deploy.js) and got published: https://stage--adp-devsite-stage--adobedocs.aem.page/github-actions-test/adp-site-metadata.json