### PR TITLE
Revert build site metadata during deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -72,32 +72,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Checkout Utils Repo
-        uses: actions/checkout@v4
-        with:
-          repository: AdobeDocs/adp-devsite-utils
-          path: utils
-          ref: build-site-metadata
-
-      - name: Install utils dependencies
-        run: |
-          cd utils
-          npm install
-
-      - name: Build site metadata
-        run: node utils/bin/buildSiteMetadata.js -v
-
-      - name: Commit site metadata if changed
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add src/pages/adp-site-metadata.json
-          if ! git diff --cached --quiet; then
-            git commit -m "chore: update site metadata [skip ci]"
-            git pull --rebase
-            git push
-          fi
-
       - name: Checkout Scripts Repo
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,7 +77,7 @@ jobs:
         with:
           repository: AdobeDocs/adp-devsite-utils
           path: utils
-          ref: main
+          ref: build-site-metadata
 
       - name: Install utils dependencies
         run: |


### PR DESCRIPTION
Revert https://github.com/AdobeDocs/adp-devsite-workflow/pull/16 to unblock Dima from deployment. He is currently unable to bypass branch protection rule to allow the commit that auto-generates `site-medata.json`: https://adobeio.slack.com/archives/C01GU3V8XE0/p1771873784634579