### PR TITLE
feat: add reusable workflow for generating site metadata in PRs

### DIFF
--- a/.github/workflows/build-site-metadata.yml
+++ b/.github/workflows/build-site-metadata.yml
@@ -1,0 +1,26 @@
+---
+name: Build Site Metadata
+on:
+  workflow_call:
+
+jobs:
+  build-site-metadata:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+
+      - name: Build Site Metadata
+        run: npx --yes github:AdobeDocs/adp-devsite-utils buildSiteMetadata -v
+
+      - name: Commit and push if changed
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add src/pages/adp-site-metadata.json
+          git diff --cached --quiet || git commit -m "Generate site metadata"
+          git push


### PR DESCRIPTION
## Description
Add a reusable workflow that a thin caller workflow in content repos can call to generate `adp-site-metadata.json` in a PR.

## Context
 Previously generation was done [during deploy](https://github.com/AdobeDocs/adp-devsite-workflow/pull/16), but that was [reverted](https://github.com/AdobeDocs/adp-devsite-workflow/pull/17) because it violated branch protection rules with no clean way to bypass them. Moving it to PRs instead lets the generated file merge into the branch normally and get published like any other content file.

## Next step
Add thin caller workflow in to content repos in https://github.com/AdobeDocs/dev-docs-template/pull/29

## Ticket
https://jira.corp.adobe.com/browse/DEVSITE-2217

## Test

1. Open up a [test PR](https://github.com/AdobeDocs/adp-devsite-github-actions-test/pull/104) (that has a content change and [thin caller workflow](https://github.com/AdobeDocs/adp-devsite-github-actions-test/blob/a066ffc5339947a457361e6c22ced0be79fdb595/.github/workflows/build-site-metadata.yml#L10))

2. Notice `Build Site Metadata` workflow is triggered

<img width="1441" height="1045" alt="Screenshot 2026-02-25 at 11 18 29 AM" src="https://github.com/user-attachments/assets/58a88296-2b85-4271-96ec-32ccebc527e6" />

3. Notice `adp-devsite-metadata.json` gets generated and commited

<img width="1440" height="526" alt="Screenshot 2026-02-25 at 11 18 09 AM" src="https://github.com/user-attachments/assets/26493cdc-e6d4-44b9-99da-401dd378fa47" />

4. Merge and [deploy](https://github.com/AdobeDocs/adp-devsite-github-actions-test/actions/runs/22412612565/job/64889882958)

5. Notice `adp-devsite-metadata.json` gets published like any other content file

<img width="1439" height="1045" alt="Screenshot 2026-02-25 at 11 38 31 AM" src="https://github.com/user-attachments/assets/93e3655a-a352-43d0-9501-5eae1db971a7" />

6. It's [previewed](https://stage--adp-devsite-stage--adobedocs.aem.page/github-actions-test/adp-site-metadata.json) on stage