### PR TITLE
feat: build contributors

### DIFF
--- a/.github/workflows/build-contributors.yml
+++ b/.github/workflows/build-contributors.yml
@@ -1,0 +1,37 @@
+---
+name: Build Contributors
+on:
+  workflow_call:
+
+jobs:
+  build-contributors:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0
+
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.ADP_DEVSITE_APP_ID }}
+          private-key: ${{ secrets.ADP_DEVSITE_APP_PRIVATE_KEY }}
+
+      - name: Build Contributors
+        run: npx --yes github:AdobeDocs/adp-devsite-utils buildContributors -v
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      - name: Commit and push if changed
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add src/pages/contributors.json
+          git diff --cached --quiet || git commit -m "Generate contributors"
+          git pull --rebase
+          git push

--- a/.github/workflows/build-site-metadata.yml
+++ b/.github/workflows/build-site-metadata.yml
@@ -23,4 +23,5 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add src/pages/adp-site-metadata.json
           git diff --cached --quiet || git commit -m "Generate site metadata"
+          git pull --rebase
           git push


### PR DESCRIPTION
## Description
Add a reusable workflow to generate and commit contributor data during PRs.

## Notes
`ADP_DEVSITE_APP_ID` and `ADP_DEVSITE_APP_PRIVATE_KEY` are used to authenticate as the ADP DevSite GitHub App and obtain a token that can call the GitHub API (for contributor data) and push commits back to the repository.
<img width="1457" height="1042" alt="Screenshot 2026-03-06 at 2 59 20 PM" src="https://github.com/user-attachments/assets/b5132846-880f-42fa-87e2-7b9d339509b0" />
<img width="1460" height="1048" alt="Screenshot 2026-03-06 at 3 25 10 PM" src="https://github.com/user-attachments/assets/9a041bb2-7ba4-4791-8637-bf129fdbd957" />


## Ticket
https://jira.corp.adobe.com/browse/DEVSITE-2091

## Pre-req
- Merge https://github.com/AdobeDocs/adp-devsite-utils/pull/48 first
- Then point to main https://github.com/AdobeDocs/adp-devsite-workflow/pull/19/changes#r2881076325

## Test
Tested in https://github.com/AdobeDocs/adp-devsite-utils/pull/48