### PR TITLE
fix: build auto-generated files

### DIFF
--- a/.github/workflows/build-auto-generated-files.yml
+++ b/.github/workflows/build-auto-generated-files.yml
@@ -1,0 +1,19 @@
+---
+name: Build Auto-Generated Files
+on:
+  workflow_call:
+
+jobs:
+  build-contributors:
+    name: Build Contributors
+    if: github.repository != 'AdobeDocs/dev-docs-template'
+    uses: ./.github/workflows/build-contributors.yml
+    secrets: inherit
+
+  build-site-metadata:
+    name: Build Site Metadata
+    needs: build-contributors
+    if: |
+      always() &&
+      github.repository != 'AdobeDocs/dev-docs-template'
+    uses: ./.github/workflows/build-site-metadata.yml


### PR DESCRIPTION
## Issue
A race condition causes `build-site-metadata.yml` to run twice in a PR:
<img width="1078" height="561" alt="Screenshot 2026-03-11 at 3 25 59 PM" src="https://github.com/user-attachments/assets/69e75926-cf1b-45e1-8149-604d138b4941" />


## Fix
Replace the separate `build-site-metadata.yml` and `build-contributors.yml` caller workflows in content repos with a single `build-auto-generated-files.yml` workflow that:
- uses [needs](https://github.com/AdobeDocs/adp-devsite-workflow/blob/1b821a565d9c3a113506808d3420e5d9966f823e/.github/workflows/build-auto-generated-files.yml#L16) to sequence `buildContributors.yml` before `buildSiteMetadata.yml`
- uses [always](https://github.com/AdobeDocs/adp-devsite-workflow/blob/1b821a565d9c3a113506808d3420e5d9966f823e/.github/workflows/build-auto-generated-files.yml#L18) to still run `buildSiteMetadata.yml` regardless of `buildContributors.yml` outcome

This way `build-site-metadata.yml` only needs to run once:

<img width="1350" height="725" alt="Screenshot 2026-03-13 at 1 33 00 PM copy" src="https://github.com/user-attachments/assets/40676771-2304-4fcf-8de0-2f32f7545a4b" />

## Related PR
https://github.com/AdobeDocs/dev-docs-template/pull/41

## Ticket
https://jira.corp.adobe.com/browse/DEVSITE-2259