### PR TITLE
fix: reject branch names with slashes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,6 +49,13 @@ jobs:
         run: echo "branch=${GITHUB_REF#refs/heads/}" >> "$GITHUB_OUTPUT"
         id: get_branch
 
+      - name: Validate branch name
+        if: contains(steps.get_branch.outputs.branch, '/')
+        uses: actions/github-script@v7
+        with:
+          script: |
+            core.setFailed("Branch name '${{ steps.get_branch.outputs.branch }}' contains a slash (/), which is not supported by EDS. Please rename your branch to remove the slash and try again.");
+
   echo-state:
     needs: [set-state]
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description
Add a validation step that catches branch names containing slashes before the deploy starts, giving authors an immediate error instead of a series of individual file failures.

## Ticket
https://jira.corp.adobe.com/browse/DEVSITE-2108

## Before
Branch with slash causes individual file failures:
<img width="1728" height="1044" alt="Screenshot 2026-03-18 at 8 24 36 AM" src="https://github.com/user-attachments/assets/d8e2aef9-c660-48af-81b7-297c8ea62805" />

## After
Branch with slash now fails fast with a clear error:
<img width="1728" height="1044" alt="Screenshot 2026-03-18 at 8 24 04 AM" src="https://github.com/user-attachments/assets/a928925e-0dc0-403d-97a6-2c923ec0e1ae" />
