### PR TITLE
feat: generate auto-generated files during deploy using App token

### DIFF
--- a/.github/workflows/build-auto-generated-files.yml
+++ b/.github/workflows/build-auto-generated-files.yml
@@ -2,13 +2,20 @@
 name: Build Auto-Generated Files
 on:
   workflow_call:
+    secrets:
+      ADP_DEVSITE_APP_ID:
+        required: true
+      ADP_DEVSITE_APP_PRIVATE_KEY:
+        required: true
 
 jobs:
   build-contributors:
     name: Build Contributors
     if: github.repository != 'AdobeDocs/dev-docs-template'
     uses: ./.github/workflows/build-contributors.yml
-    secrets: inherit
+    secrets:
+      ADP_DEVSITE_APP_ID: ${{ secrets.ADP_DEVSITE_APP_ID }}
+      ADP_DEVSITE_APP_PRIVATE_KEY: ${{ secrets.ADP_DEVSITE_APP_PRIVATE_KEY }}
 
   build-site-metadata:
     name: Build Site Metadata
@@ -17,3 +24,6 @@ jobs:
       always() &&
       github.repository != 'AdobeDocs/dev-docs-template'
     uses: ./.github/workflows/build-site-metadata.yml
+    secrets:
+      ADP_DEVSITE_APP_ID: ${{ secrets.ADP_DEVSITE_APP_ID }}
+      ADP_DEVSITE_APP_PRIVATE_KEY: ${{ secrets.ADP_DEVSITE_APP_PRIVATE_KEY }}

--- a/.github/workflows/build-contributors.yml
+++ b/.github/workflows/build-contributors.yml
@@ -2,6 +2,11 @@
 name: Build Contributors
 on:
   workflow_call:
+    secrets:
+      ADP_DEVSITE_APP_ID:
+        required: true
+      ADP_DEVSITE_APP_PRIVATE_KEY:
+        required: true
 
 jobs:
   build-contributors:
@@ -12,8 +17,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Generate GitHub App token
         id: app-token
@@ -31,7 +36,8 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/${{ github.repository }}
+          git pull
           git add src/pages/contributors.json
           git diff --cached --quiet || git commit -m "Generate contributors"
-          git pull --rebase
           git push

--- a/.github/workflows/build-site-metadata.yml
+++ b/.github/workflows/build-site-metadata.yml
@@ -2,6 +2,11 @@
 name: Build Site Metadata
 on:
   workflow_call:
+    secrets:
+      ADP_DEVSITE_APP_ID:
+        required: true
+      ADP_DEVSITE_APP_PRIVATE_KEY:
+        required: true
 
 jobs:
   build-site-metadata:
@@ -12,7 +17,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
+          persist-credentials: false
+
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.ADP_DEVSITE_APP_ID }}
+          private-key: ${{ secrets.ADP_DEVSITE_APP_PRIVATE_KEY }}
 
       - name: Build Site Metadata
         run: npx --yes github:AdobeDocs/adp-devsite-utils buildSiteMetadata -v
@@ -21,7 +33,8 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/${{ github.repository }}
+          git pull
           git add src/pages/adp-site-metadata.json
           git diff --cached --quiet || git commit -m "Generate site metadata"
-          git pull --rebase
           git push

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,8 +12,21 @@ on:
       deployAll:
         type: boolean
         default: false
+    secrets:
+      ADP_DEVSITE_APP_ID:
+        required: true
+      ADP_DEVSITE_APP_PRIVATE_KEY:
+        required: true
 
 jobs:
+  build-auto-generated-files:
+    name: Build Auto-Generated Files
+    if: github.repository != 'AdobeDocs/dev-docs-template' && github.actor != 'adp-devsite-bot[bot]'
+    uses: ./.github/workflows/build-auto-generated-files.yml
+    secrets:
+      ADP_DEVSITE_APP_ID: ${{ secrets.ADP_DEVSITE_APP_ID }}
+      ADP_DEVSITE_APP_PRIVATE_KEY: ${{ secrets.ADP_DEVSITE_APP_PRIVATE_KEY }}
+
   set-state:
     runs-on: ubuntu-latest
     outputs:


### PR DESCRIPTION
## Ticket
https://jira.corp.adobe.com/browse/DEVSITE-2292

## Issue

`buildContributors` and `buildSiteMetadata` fail in two scenarios:
- Fork PRs - workflow doesn't have write access to the fork's branch (e.g. [commerce-php](https://github.com/AdobeDocs/commerce-php/actions/runs/23320239545/job/67829722528?pr=437))

<img width="1728" height="1042" alt="Screenshot 2026-03-30 at 2 41 17 PM" src="https://github.com/user-attachments/assets/e351d62d-e533-46f4-a271-894a6196d366" />

- Repos with branch protection - default token is blocked from pushing to the deploy branch during deploy (e.g. [commerce-pwa-studio](https://github.com/AdobeDocs/commerce-pwa-studio/actions/runs/22318784641/job/64571075698))

<img width="1724" height="1044" alt="Screenshot 2026-03-30 at 2 40 15 PM" src="https://github.com/user-attachments/assets/f614842c-eb8b-4d99-bc64-eabe6adb56d4" />


## Fix

Move auto-generation to deploy and use a GitHub App token (instead of the default `GITHUB_TOKEN`) to push `contributors.json` and `adp-site-metadata.json` to the deploy branch. This allows repos with branch protection to add `ADP DevSite Bot` as a bypass actor in their ruleset, granting the workflow permission to push directly.

Key implementation details:

- **`persist-credentials: false`** on the checkout step in both `build-contributors.yml` and `build-site-metadata.yml`. Without this, the default `GITHUB_TOKEN` persisted by `actions/checkout` overrides the app token on push, preventing the bypass actor from being recognized. ([GitHub Community reference](https://github.com/orgs/community/discussions/136531))
- **Pull before generating** — `git pull` is run before the build step so the generated file always starts from the latest remote state, preventing add/add conflicts when a previous run's file already exists on the branch.
- **Skip auto-generation on bot-pushed commits** — the deploy workflow skips `build-auto-generated-files` when triggered by `adp-devsite-bot[bot]` to prevent an infinite deploy loop.
- **`ADP_DEVSITE_APP_ID`** and **`ADP_DEVSITE_APP_PRIVATE_KEY`** (credentials for `ADP DevSite Bot`) are set as org-level secrets on both [AdobeDocs](https://github.com/organizations/AdobeDocs/settings/secrets/actions) and [AdobeDocsPrivate](https://github.com/organizations/AdobeDocsPrivate/settings/secrets/actions), and [ADP DevSite Bot](https://github.com/settings/apps/adp-devsite-bot/installations) is installed on both orgs.

Content repos with branch protection must add `ADP DevSite Bot` as a bypass actor in their ruleset. Repos without branch protection require no changes.

## Test

- [ ] Deploy on `AdobeDocs` repo, branch protection, no bypass → push rejected (expected)

https://github.com/AdobeDocs/adp-devsite-branch-protection-test/actions/runs/23827439498/workflow


- [ ] Deploy on `AdobeDocs` repo, branch protection + App as bypass actor → files committed

https://github.com/AdobeDocs/adp-devsite-branch-protection-test/actions/runs/23827708496/workflow

- [ ] Deploy on `AdobeDocs` repo, no branch protection → files committed

https://github.com/AdobeDocs/adp-devsite-github-actions-test/actions/runs/23830002361/workflow


- [ ] Deploy on `AdobeDocsPrivate` repo, no branch protection → files committed

https://github.com/AdobeDocsPrivate/adp-dev-docs-private/actions/runs/23830456353/workflow
