### PR TITLE
feat: auto-generate files on deploy

### DIFF
--- a/.github/workflows/build-auto-generated-files.yml
+++ b/.github/workflows/build-auto-generated-files.yml
@@ -2,13 +2,31 @@
 name: Build Auto-Generated Files
 on:
   workflow_call:
+    inputs:
+      baseSha:
+        type: string
+        required: false
+      buildAll:
+        type: boolean
+        required: false
+        default: false
+    secrets:
+      ADP_DEVSITE_APP_ID:
+        required: true
+      ADP_DEVSITE_APP_PRIVATE_KEY:
+        required: true
 
 jobs:
   build-contributors:
     name: Build Contributors
     if: github.repository != 'AdobeDocs/dev-docs-template'
     uses: ./.github/workflows/build-contributors.yml
-    secrets: inherit
+    with:
+      baseSha: ${{ inputs.baseSha }}
+      buildAll: ${{ inputs.buildAll }}
+    secrets:
+      ADP_DEVSITE_APP_ID: ${{ secrets.ADP_DEVSITE_APP_ID }}
+      ADP_DEVSITE_APP_PRIVATE_KEY: ${{ secrets.ADP_DEVSITE_APP_PRIVATE_KEY }}
 
   build-site-metadata:
     name: Build Site Metadata
@@ -17,3 +35,6 @@ jobs:
       always() &&
       github.repository != 'AdobeDocs/dev-docs-template'
     uses: ./.github/workflows/build-site-metadata.yml
+    secrets:
+      ADP_DEVSITE_APP_ID: ${{ secrets.ADP_DEVSITE_APP_ID }}
+      ADP_DEVSITE_APP_PRIVATE_KEY: ${{ secrets.ADP_DEVSITE_APP_PRIVATE_KEY }}

--- a/.github/workflows/build-contributors.yml
+++ b/.github/workflows/build-contributors.yml
@@ -2,6 +2,19 @@
 name: Build Contributors
 on:
   workflow_call:
+    inputs:
+      baseSha:
+        type: string
+        required: false
+      buildAll:
+        type: boolean
+        required: false
+        default: false
+    secrets:
+      ADP_DEVSITE_APP_ID:
+        required: true
+      ADP_DEVSITE_APP_PRIVATE_KEY:
+        required: true
 
 jobs:
   build-contributors:
@@ -12,8 +25,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Generate GitHub App token
         id: app-token
@@ -23,15 +36,17 @@ jobs:
           private-key: ${{ secrets.ADP_DEVSITE_APP_PRIVATE_KEY }}
 
       - name: Build Contributors
-        run: npx --yes github:AdobeDocs/adp-devsite-utils buildContributors -v
+        run: npx --yes github:AdobeDocs/adp-devsite-utils buildContributors -v ${{ inputs.buildAll && '--all' || '' }}
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          BASE_SHA: ${{ inputs.baseSha || github.event.before }}
 
       - name: Commit and push if changed
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/${{ github.repository }}
+          git pull
           git add src/pages/contributors.json
-          git diff --cached --quiet || git commit -m "Generate contributors"
-          git pull --rebase
+          git diff --cached --quiet || git commit -m "chore: auto-generate contributors"
           git push

--- a/.github/workflows/build-site-metadata.yml
+++ b/.github/workflows/build-site-metadata.yml
@@ -2,6 +2,11 @@
 name: Build Site Metadata
 on:
   workflow_call:
+    secrets:
+      ADP_DEVSITE_APP_ID:
+        required: true
+      ADP_DEVSITE_APP_PRIVATE_KEY:
+        required: true
 
 jobs:
   build-site-metadata:
@@ -12,7 +17,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
+          persist-credentials: false
+
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.ADP_DEVSITE_APP_ID }}
+          private-key: ${{ secrets.ADP_DEVSITE_APP_PRIVATE_KEY }}
 
       - name: Build Site Metadata
         run: npx --yes github:AdobeDocs/adp-devsite-utils buildSiteMetadata -v
@@ -21,7 +33,8 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/${{ github.repository }}
           git add src/pages/adp-site-metadata.json
-          git diff --cached --quiet || git commit -m "Generate site metadata"
-          git pull --rebase
+          git pull
+          git diff --cached --quiet || git commit -m "chore: auto-generate site metadata"
           git push

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,22 +12,61 @@ on:
       deployAll:
         type: boolean
         default: false
+    secrets:
+      ADP_DEVSITE_APP_ID:
+        required: true
+      ADP_DEVSITE_APP_PRIVATE_KEY:
+        required: true
 
 jobs:
+  get-base-sha:
+    runs-on: ubuntu-latest
+    outputs:
+      base_sha: ${{ steps.last_successful_workflow_dispatch_run.outputs.base_sha }}
+    steps:
+      - name: Get last successful workflow_dispatch run
+        id: last_successful_workflow_dispatch_run
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const branch = context.ref.replace('refs/heads/', '');
+            const workflowId = '${{ contains(inputs.env, 'prod') && 'deploy.yml' || 'stage.yml' }}';
+            try {
+              const workflowRuns = await github.rest.actions.listWorkflowRuns({
+                owner,
+                repo,
+                workflow_id: workflowId,
+                branch: branch,
+                event: 'workflow_dispatch',
+                status: 'success',
+                per_page: 1,
+              });
+              if (workflowRuns.data.workflow_runs.length > 0) {
+                core.setOutput('base_sha',workflowRuns.data.workflow_runs[0].head_sha);
+              } else {
+                core.setOutput('base_sha','');
+              }
+            } catch (error) {
+              console.log(`Error fetching workflow runs: ${error.message}`);
+              core.setOutput('base_sha','');
+            }
+
   set-state:
+    needs: [get-base-sha]
     runs-on: ubuntu-latest
     outputs:
       path_prefix: ${{ steps.get_path_prefix.outputs.path_prefix }}
       branch_short_ref: ${{ steps.get_branch.outputs.branch }}
       deploy_stage: ${{ contains(inputs.env, 'stage') }}
       deploy_prod: ${{ contains(inputs.env, 'prod') }}
-      base_Sha: ${{ inputs.baseSha }}
-      deploy_All: ${{ inputs.deployAll }}
+      base_sha: ${{ inputs.baseSha || needs.get-base-sha.outputs.base_sha }}
+      deploy_all: ${{ inputs.deployAll }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-  
+
       - name: Checkout Scripts Repo
         uses: actions/checkout@v4
         with:
@@ -66,14 +105,27 @@ jobs:
       - run: echo "Repository org - ${{ github.event.repository.owner.login }}"
       - run: echo "Repository name - ${{ github.event.repository.name }}"
       - run: echo "Repository branch - ${{ needs.set-state.outputs.branch_short_ref }}"
-      - run: echo "Base Sha - ${{ needs.set-state.outputs.base_Sha }}"
-      - run: echo "Deploy All - ${{ needs.set-state.outputs.deploy_All }}"
+      - run: echo "Base Sha - ${{ needs.set-state.outputs.base_sha }}"
+      - run: echo "Deploy All - ${{ needs.set-state.outputs.deploy_all }}"
+
+  build-auto-generated-files:
+    name: Build Auto-Generated Files
+    needs: [set-state]
+    if: github.repository != 'AdobeDocs/dev-docs-template'
+    uses: ./.github/workflows/build-auto-generated-files.yml
+    with:
+      baseSha: ${{ needs.set-state.outputs.base_sha }}
+      buildAll: ${{ inputs.deployAll }}
+    secrets:
+      ADP_DEVSITE_APP_ID: ${{ secrets.ADP_DEVSITE_APP_ID }}
+      ADP_DEVSITE_APP_PRIVATE_KEY: ${{ secrets.ADP_DEVSITE_APP_PRIVATE_KEY }}
 
   deploy:
     defaults:
       run:
         shell: bash
-    needs: [set-state]
+    needs: [set-state, build-auto-generated-files]
+    if: always()
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -86,45 +138,15 @@ jobs:
           path: scripts
           ref: main
 
-      - name: Get last successful workflow_dispatch run
-        id: last_successful_workflow_dispatch_run
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const { owner, repo } = context.repo;
-            const branch = '${{ needs.set-state.outputs.branch_short_ref }}';
-            const workflowId = '${{ needs.set-state.outputs.deploy_prod == 'true' && 'deploy.yml' || 'stage.yml' }}';
+      - name: Pull auto-generated file commits
+        run: git pull
 
-            try {
-              const workflowRuns = await github.rest.actions.listWorkflowRuns({
-                owner,
-                repo,
-                workflow_id: workflowId,
-                branch: branch,
-                event: 'workflow_dispatch',
-                status: 'success',
-                per_page: 1, // Only need the latest one
-              });
-
-              if (workflowRuns.data.workflow_runs.length > 0) {
-                const lastSuccessfulRun = workflowRuns.data.workflow_runs[0];
-                console.log(`Last successful workflow_dispatch run on branch '${branch}':`);
-                console.log(`ID: ${lastSuccessfulRun.id}`);
-                console.log(`Commit SHA: ${lastSuccessfulRun.head_sha}`);
-                console.log(`Run URL: ${lastSuccessfulRun.html_url}`);
-                core.setOutput('base', lastSuccessfulRun.head_sha);
-              } else {
-                console.log(`No successful workflow_dispatch runs found on branch '${branch}' for workflow '${workflowId}'.`);
-                core.setOutput('base', '');
-              }
-            } catch (error) {
-              console.log(`Error fetching workflow runs: ${error.message}`);
-              console.log(`Workflow '${workflowId}' may not exist in this repository. Defaulting base to empty string.`);
-              core.setOutput('base', '');
-            }
+      - name: Get head SHA
+        id: get-head-sha
+        run: echo "head_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Get changed files in the src/pages folder
-        if: needs.set-state.outputs.deploy_All == 'false'
+        if: needs.set-state.outputs.deploy_all == 'false'
         id: changed-files-specific
         uses: tj-actions/changed-files@v46.0.5
         with:
@@ -132,10 +154,11 @@ jobs:
           escape_json: false
           files: |
             src/pages/**
-          base_sha: ${{ needs.set-state.outputs.base_Sha || steps.last_successful_workflow_dispatch_run.outputs.base }}
+          sha: ${{ steps.get-head-sha.outputs.head_sha }}
+          base_sha: ${{ needs.set-state.outputs.base_sha }}
 
       - name: Get all files from src/pages folder
-        if: needs.set-state.outputs.deploy_All == 'true'
+        if: needs.set-state.outputs.deploy_all == 'true'
         id: all-files
         uses: actions/github-script@v7
         with:
@@ -156,7 +179,7 @@ jobs:
             core.setOutput('all_files', serializedAllFiles);
 
       - name: Deploy only changed files to stage
-        if: needs.set-state.outputs.deploy_stage == 'true' && steps.changed-files-specific.outputs.any_modified == 'true' && needs.set-state.outputs.deploy_All == 'false'
+        if: needs.set-state.outputs.deploy_stage == 'true' && steps.changed-files-specific.outputs.any_modified == 'true' && needs.set-state.outputs.deploy_all == 'false'
         uses: actions/github-script@v7
         with:
           script: |
@@ -173,7 +196,7 @@ jobs:
             });
 
       - name: Force deploy all files to stage
-        if: needs.set-state.outputs.deploy_stage == 'true' && needs.set-state.outputs.deploy_All == 'true'
+        if: needs.set-state.outputs.deploy_stage == 'true' && needs.set-state.outputs.deploy_all == 'true'
         uses: actions/github-script@v7
         with:
           script: |
@@ -195,7 +218,7 @@ jobs:
         shell: bash
 
       - name: Clean cache on only changed files on stage
-        if: needs.set-state.outputs.deploy_stage == 'true' && steps.changed-files-specific.outputs.any_modified == 'true' && needs.set-state.outputs.deploy_All == 'false'
+        if: needs.set-state.outputs.deploy_stage == 'true' && steps.changed-files-specific.outputs.any_modified == 'true' && needs.set-state.outputs.deploy_all == 'false'
         uses: actions/github-script@v7
         with:
           script: |
@@ -212,7 +235,7 @@ jobs:
             });
 
       - name: Clean cache on all files on stage
-        if: needs.set-state.outputs.deploy_stage == 'true' && needs.set-state.outputs.deploy_All == 'true'
+        if: needs.set-state.outputs.deploy_stage == 'true' && needs.set-state.outputs.deploy_all == 'true'
         uses: actions/github-script@v7
         with:
           script: |
@@ -229,7 +252,7 @@ jobs:
             });
 
       - name: Deploy only changed files to prod (Step 1 of 2)
-        if: needs.set-state.outputs.deploy_prod == 'true' && steps.changed-files-specific.outputs.any_modified == 'true' && needs.set-state.outputs.deploy_All == 'false'
+        if: needs.set-state.outputs.deploy_prod == 'true' && steps.changed-files-specific.outputs.any_modified == 'true' && needs.set-state.outputs.deploy_all == 'false'
         uses: actions/github-script@v7
         with:
           script: |
@@ -246,7 +269,7 @@ jobs:
             });
 
       - name: Force deploy all files to prod (Step 1 of 2)
-        if: needs.set-state.outputs.deploy_prod == 'true' && needs.set-state.outputs.deploy_All == 'true'
+        if: needs.set-state.outputs.deploy_prod == 'true' && needs.set-state.outputs.deploy_all == 'true'
         uses: actions/github-script@v7
         with:
           script: |
@@ -268,7 +291,7 @@ jobs:
         shell: bash
 
       - name: Deploy only changed files to prod (Step 2 of 2)
-        if: needs.set-state.outputs.deploy_prod == 'true' && steps.changed-files-specific.outputs.any_modified == 'true' && needs.set-state.outputs.deploy_All == 'false'
+        if: needs.set-state.outputs.deploy_prod == 'true' && steps.changed-files-specific.outputs.any_modified == 'true' && needs.set-state.outputs.deploy_all == 'false'
         uses: actions/github-script@v7
         with:
           script: |
@@ -285,7 +308,7 @@ jobs:
             });
 
       - name: Force deploy all files to prod (Step 2 of 2)
-        if: needs.set-state.outputs.deploy_prod == 'true' && needs.set-state.outputs.deploy_All == 'true'
+        if: needs.set-state.outputs.deploy_prod == 'true' && needs.set-state.outputs.deploy_all == 'true'
         uses: actions/github-script@v7
         with:
           script: |
@@ -307,7 +330,7 @@ jobs:
         shell: bash
 
       - name: Clean cache on only changed files on prod
-        if: needs.set-state.outputs.deploy_prod == 'true' && steps.changed-files-specific.outputs.any_modified == 'true' && needs.set-state.outputs.deploy_All == 'false'
+        if: needs.set-state.outputs.deploy_prod == 'true' && steps.changed-files-specific.outputs.any_modified == 'true' && needs.set-state.outputs.deploy_all == 'false'
         uses: actions/github-script@v7
         with:
           script: |
@@ -334,7 +357,7 @@ jobs:
             });
 
       - name: Clean cache on all files on prod
-        if: needs.set-state.outputs.deploy_prod == 'true' && needs.set-state.outputs.deploy_All == 'true'
+        if: needs.set-state.outputs.deploy_prod == 'true' && needs.set-state.outputs.deploy_all == 'true'
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
## Ticket
https://jira.corp.adobe.com/browse/DEVSITE-2292

## Issue
Previously, contributors and site metadata are auto-generated during PR. This fails in two scenarios:

- **Fork PRs** - the workflow doesn't have write access to the fork's branch (e.g. [commerce-php](https://github.com/AdobeDocs/commerce-php/actions/runs/23320239545/job/67829722528?pr=437))

<img width="1728" height="1042" alt="Screenshot 2026-03-30 at 2 41 17 PM" src="https://github.com/user-attachments/assets/e351d62d-e533-46f4-a271-894a6196d366" />

- **Repos with branch protection** - the default token is blocked from pushing to the deploy branch (e.g. [commerce-pwa-studio](https://github.com/AdobeDocs/commerce-pwa-studio/actions/runs/22318784641/job/64571075698))

<img width="1724" height="1044" alt="Screenshot 2026-03-30 at 2 40 15 PM" src="https://github.com/user-attachments/assets/f614842c-eb8b-4d99-bc64-eabe6adb56d4" />

## Fix
Auto-generate contributors and site metadata during deploy using a GitHub App token to push to the deploy branch. This ensures the workflow always has write access to the base repo branch and allows `ADP DevSite App` to be added as a bypass actor in repos with branch protection.

Fork PRs are fixed implicitly - since auto-generation no longer runs on PRs, the fork branch is never written to.

## Setup

- `ADP_DEVSITE_APP_ID` and `ADP_DEVSITE_APP_PRIVATE_KEY` are set as org-level secrets on [AdobeDocs](https://github.com/organizations/AdobeDocs/settings/secrets/actions) and [AdobeDocsPrivate](https://github.com/organizations/AdobeDocsPrivate/settings/secrets/actions). Private repos on AdobeDocsPrivate also require repo-level secrets since the free plan does not support org-level secrets for private repos. [ADP DevSite App](https://github.com/apps/adp-devsite-app) is installed on both orgs.
- Content repos with branch protection must add `ADP DevSite App` as a bypass actor in their ruleset. Repos without branch protection require no changes.

## Implementation Notes

- **`persist-credentials: false`** on the checkout step in both `build-contributors.yml` and `build-site-metadata.yml`. Without this, the default `GITHUB_TOKEN` persisted by `actions/checkout` overrides the app token on push, preventing the bypass actor from being recognized. ([actions/create-github-app-token README](https://github.com/actions/create-github-app-token), [Discussion #75](https://github.com/actions/create-github-app-token/discussions/75))
- **`fetch-depth: 0`** on the checkout step in `build-contributors.yml` - required for delta builds so `git diff` has access to the full commit history when comparing against `BASE_SHA`.
- **Delta builds** - `build-auto-generated-files` mirrors the deploy diff. `BASE_SHA` is threaded from `set-state` through to `buildContributors.js` so only markdown files changed since the last deploy are processed. On push events, `BASE_SHA` is `github.event.before`. On `workflow_dispatch`, it falls back to the last successful run SHA via `get-base-sha`. If no SHA is available, a full build runs.
- **`if: github.actor != 'adp-devsite-app[bot]'`** on the `deployment` job in each content repo's `deploy.yml` - prevents bot commits of auto-generated files from triggering a new deploy indefinitely. Placed in the calling repo rather than inside `adp-devsite-workflow` because GitHub Actions has no workflow-level `if` condition for reusable workflows.
- **Cross-org repos (AdobeDocsPrivate)** - `ADP DevSite App` is owned by AdobeDocs but installed on AdobeDocsPrivate. Secrets must be passed explicitly rather than via `secrets: inherit`, which does not work across org boundaries.

## Pre-requisites
These need to be merged first
- https://github.com/AdobeDocs/adp-devsite-utils/pull/68 
- https://github.com/AdobeDocs/dev-docs-template/pull/46 

## Test
| User Action | Repo Config | Expected | Screenshots |
|---|---|---|---|
| Push to main with markdown changes | any | delta build runs, auto-generated files included in deploy diff | https://github.com/AdobeDocs/adp-devsite-branch-protection-test/actions/runs/23888572210 <img width="1728" height="1046" alt="Screenshot 2026-04-02 at 12 16 05 AM" src="https://github.com/user-attachments/assets/618c9add-8311-46f5-abb7-8821ffcea24b" /> <img width="1728" height="1046" alt="Screenshot 2026-04-02 at 12 18 19 AM" src="https://github.com/user-attachments/assets/a0b97970-5ec8-4f05-85e1-762549af9ddd" /> |
| workflow_dispatch, baseSha provided, deployAll unchecked | any | delta build runs from baseSha provided | https://github.com/AdobeDocs/adp-devsite-branch-protection-test/actions/runs/23889054804 <img width="1728" height="1047" alt="Screenshot 2026-04-02 at 12 22 19 AM" src="https://github.com/user-attachments/assets/a9813a82-83a3-454e-8728-54db2d1e530e" /> <img width="1728" height="1045" alt="Screenshot 2026-04-02 at 12 25 51 AM" src="https://github.com/user-attachments/assets/42ec83cc-dc52-4cd6-9ca2-557da635fee1" /> <img width="1728" height="1046" alt="Screenshot 2026-04-02 at 12 26 28 AM" src="https://github.com/user-attachments/assets/2097a870-963d-4c1f-a6b9-a1519ffba012" /> |
| workflow_dispatch, no baseSha, deployAll unchecked | any | delta build runs from last successful run SHA | https://github.com/AdobeDocs/adp-devsite-branch-protection-test/actions/runs/23889290126 <img width="1728" height="1043" alt="Screenshot 2026-04-02 at 12 29 00 AM" src="https://github.com/user-attachments/assets/18732abc-a28d-47e7-a932-f91c0c1aaac8" /> <img width="1728" height="1046" alt="Screenshot 2026-04-02 at 12 32 27 AM" src="https://github.com/user-attachments/assets/a9deb8d3-10a2-4d3c-8345-2593ec96b94d" /> <img width="1728" height="1044" alt="Screenshot 2026-04-02 at 12 32 38 AM" src="https://github.com/user-attachments/assets/2e13be15-17d7-46f5-8236-dbc2e8b56f01" /> |
| workflow_dispatch, deployAll checked | any | full build runs regardless of baseSha | https://github.com/AdobeDocs/adp-devsite-branch-protection-test/actions/runs/23889559109 <img width="1728" height="1044" alt="Screenshot 2026-04-02 at 12 36 27 AM" src="https://github.com/user-attachments/assets/563e996c-e12d-4dd7-abbd-530ea3e7bb8c" /> <img width="1728" height="1045" alt="Screenshot 2026-04-02 at 12 39 55 AM" src="https://github.com/user-attachments/assets/d22e1518-c738-4619-8bf6-63753c92993d" /> <img width="1728" height="1045" alt="Screenshot 2026-04-02 at 12 40 13 AM" src="https://github.com/user-attachments/assets/578458c8-3608-4c93-9c8f-6852860529b1" /> |
| Bot commits auto-generated files, deploy re-triggers | any | bot-triggered deploy skipped, no redundant runs | https://github.com/AdobeDocs/adp-devsite-branch-protection-test/actions/runs/23888572210 <img width="1728" height="1045" alt="Screenshot 2026-04-02 at 12 11 37 AM" src="https://github.com/user-attachments/assets/89371184-eab5-4ff0-a850-b1a0a95e0240" /> <img width="1728" height="1046" alt="Screenshot 2026-04-02 at 12 11 28 AM" src="https://github.com/user-attachments/assets/b2964034-5408-4244-88a6-0eac4aa994bf" /> |
| Push to main | branch protection + App bypass | bot push allowed | https://github.com/AdobeDocs/adp-devsite-branch-protection-test/actions/runs/23890072982 <img width="3456" height="4946" alt="screencapture-github-AdobeDocs-adp-devsite-branch-protection-test-settings-branch-protection-rules-74934415-2026-04-02-00_47_41" src="https://github.com/user-attachments/assets/6482927b-631c-47ba-9d2e-12f1c9cd8518" /> <img width="3456" height="4242" alt="screencapture-github-AdobeDocs-adp-devsite-branch-protection-test-settings-rules-14569480-2026-04-02-00_48_18" src="https://github.com/user-attachments/assets/1bda9f3b-edad-4881-8b3f-d3c274d7339b" /> <img width="1728" height="1043" alt="Screenshot 2026-04-02 at 12 54 14 AM" src="https://github.com/user-attachments/assets/fc756657-9dff-4da5-8b6d-5edddd068e55" /> <img width="1728" height="1045" alt="Screenshot 2026-04-02 at 12 55 33 AM" src="https://github.com/user-attachments/assets/5e857ba2-aabe-4d5f-89d9-4838c46ba089" /> |
| Push to main | branch protection, no App bypass | bot push rejected | https://github.com/AdobeDocs/adp-devsite-branch-protection-test/actions/runs/23890530001 <img width="3456" height="4524" alt="screencapture-github-AdobeDocs-adp-devsite-branch-protection-test-settings-branch-protection-rules-74934415-2026-04-02-01_00_19" src="https://github.com/user-attachments/assets/17344f1c-4430-4338-b83e-f4119cf5ff33" /> <img width="3456" height="4574" alt="screencapture-github-AdobeDocs-adp-devsite-branch-protection-test-settings-rules-14569480-2026-04-02-01_00_42" src="https://github.com/user-attachments/assets/2e0f6ce5-a452-4fab-a149-4eeb59a3db32" /><img width="1728" height="1041" alt="Screenshot 2026-04-02 at 1 06 03 AM" src="https://github.com/user-attachments/assets/15facc96-6de6-4581-afa7-009db1f1161c" /> <img width="1720" height="1043" alt="Screenshot 2026-04-02 at 1 06 21 AM" src="https://github.com/user-attachments/assets/290df321-b162-4bcc-a69f-db721301f45e" /> |
| Push to main | no branch protection | bot push allowed | https://github.com/AdobeDocs/adp-devsite-github-actions-test/actions/runs/23891037701 <img width="1728" height="1044" alt="Screenshot 2026-04-02 at 1 17 45 AM" src="https://github.com/user-attachments/assets/3b0adb03-588a-48d2-8764-ebd12d2c385e" /> <img width="1728" height="1045" alt="Screenshot 2026-04-02 at 1 17 54 AM" src="https://github.com/user-attachments/assets/aa3d7117-1934-4dac-867a-3f9f0550c3c7" /> <img width="1728" height="1045" alt="Screenshot 2026-04-02 at 1 19 47 AM" src="https://github.com/user-attachments/assets/503d58bb-2875-42a9-9d57-9595ce6912fd" /> <img width="1728" height="1045" alt="Screenshot 2026-04-02 at 1 20 02 AM" src="https://github.com/user-attachments/assets/7923e776-6a62-45ce-8779-89fee3f1e94c" /> |
| workflow_dispatch | AdobeDocsPrivate (cross-org) | bot push allowed | https://github.com/AdobeDocsPrivate/adp-dev-docs-private/actions/runs/23892003177 <img width="1728" height="1045" alt="Screenshot 2026-04-02 at 1 44 30 AM" src="https://github.com/user-attachments/assets/79738079-08ad-448e-8404-a6a654956ba2" /> |