### PR TITLE
fix: skip auto-generated files build when app secrets are not provided

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,9 +14,9 @@ on:
         default: false
     secrets:
       ADP_DEVSITE_APP_ID:
-        required: true
+        required: false
       ADP_DEVSITE_APP_PRIVATE_KEY:
-        required: true
+        required: false
 
 jobs:
   get-base-sha:
@@ -62,6 +62,7 @@ jobs:
       deploy_prod: ${{ contains(inputs.env, 'prod') }}
       base_sha: ${{ inputs.baseSha || needs.get-base-sha.outputs.base_sha }}
       deploy_all: ${{ inputs.deployAll }}
+      has_app_secrets: ${{ secrets.ADP_DEVSITE_APP_ID != '' }}
 
     steps:
       - name: Checkout
@@ -111,7 +112,7 @@ jobs:
   build-auto-generated-files:
     name: Build Auto-Generated Files
     needs: [set-state]
-    if: github.repository != 'AdobeDocs/dev-docs-template'
+    if: github.repository != 'AdobeDocs/dev-docs-template' && needs.set-state.outputs.has_app_secrets == 'true'
     uses: ./.github/workflows/build-auto-generated-files.yml
     with:
       baseSha: ${{ needs.set-state.outputs.base_sha }}


### PR DESCRIPTION
## Issue
Merging the [new auto-generate-on-deploy workflow](https://github.com/AdobeDocs/adp-devsite-workflow/pull/23) broke existing content repos that call `deploy.yml` without passing `ADP_DEVSITE_APP_ID` and `ADP_DEVSITE_APP_PRIVATE_KEY` — the secrets were required, causing their deploys to fail.

## Fix
Make the secrets optional and skip `build-auto-generated-files` when they are not provided, so existing callers continue to work without changes.
- Repos that [pass app secrets](https://github.com/AdobeDocs/dev-docs-template/blob/main/.github/workflows/deploy.yml#L30-L33) get auto-generation during deploy (new behavior)
- Repos that [don't pass app secrets](https://github.com/AdobeDocs/dev-docs-template/blob/db4de7ade390f0dbb07a6ef1e2cc6b3fd3211dcf/.github/workflows/deploy.yml#L29) skip auto-generation and deploy as before (backward compatible)


## Ticket 
https://jira.corp.adobe.com/browse/DEVSITE-2292

## Before
https://github.com/AdobeDocs/adp-devsite-branch-protection-test/actions/runs/23915062690
<img width="1728" height="1043" alt="Screenshot 2026-04-02 at 11 17 27 AM" src="https://github.com/user-attachments/assets/1a0760d4-d379-4a8b-840f-e2ce74bdf1a9" />

## After
https://github.com/AdobeDocs/adp-devsite-branch-protection-test/actions/runs/23915576937
<img width="1728" height="1047" alt="Screenshot 2026-04-02 at 11 28 44 AM" src="https://github.com/user-attachments/assets/a735e8bf-52f6-444b-984c-cd6a9c44758b" />
