### PR TITLE
feat: centralize AdobeDocsPrivate deployments

### DIFF
--- a/.github/matrix/runner_matrix.json
+++ b/.github/matrix/runner_matrix.json
@@ -1,0 +1,6 @@
+[
+  { "org": "AdobeDocs",        "env": "stg",  "runner": "ubuntu-latest" },
+  { "org": "AdobeDocs",        "env": "prod", "runner": "ubuntu-latest" },
+  { "org": "AdobeDocsPrivate", "env": "stg",  "runner": "developer-website-arc-stg-runners" },
+  { "org": "AdobeDocsPrivate", "env": "prod", "runner": "developer-website-arc-prd-runners" }
+]

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,17 @@ on:
       deployAll:
         type: boolean
         default: false
+    secrets:
+      AIO_AZURE_DEV_PRIVATE_CONNECTION_STRING:
+        required: false
+      AIO_AZURE_PROD_PRIVATE_CONNECTION_STRING:
+        required: false
+      AIO_FASTLY_TOKEN:
+        required: false
+      AIO_FASTLY_PROD_URL:
+        required: false
+      AIO_FASTLY_DEV_URL:
+        required: false
 
 jobs:
   set-state:
@@ -74,14 +85,24 @@ jobs:
   private-deployment-stg:
     if: github.repository_owner == 'AdobeDocsPrivate' && contains(inputs.env, 'stage')
     uses: ./.github/workflows/private-deploy.yml
-    secrets: inherit
+    secrets:
+      AIO_AZURE_DEV_PRIVATE_CONNECTION_STRING: ${{ secrets.AIO_AZURE_DEV_PRIVATE_CONNECTION_STRING }}
+      AIO_AZURE_PROD_PRIVATE_CONNECTION_STRING: ${{ secrets.AIO_AZURE_PROD_PRIVATE_CONNECTION_STRING }}
+      AIO_FASTLY_TOKEN: ${{ secrets.AIO_FASTLY_TOKEN }}
+      AIO_FASTLY_PROD_URL: ${{ secrets.AIO_FASTLY_PROD_URL }}
+      AIO_FASTLY_DEV_URL: ${{ secrets.AIO_FASTLY_DEV_URL }}
     with:
       env: stg
 
   private-deployment-prod:
     if: github.repository_owner == 'AdobeDocsPrivate' && contains(inputs.env, 'prod')
     uses: ./.github/workflows/private-deploy.yml
-    secrets: inherit
+    secrets:
+      AIO_AZURE_DEV_PRIVATE_CONNECTION_STRING: ${{ secrets.AIO_AZURE_DEV_PRIVATE_CONNECTION_STRING }}
+      AIO_AZURE_PROD_PRIVATE_CONNECTION_STRING: ${{ secrets.AIO_AZURE_PROD_PRIVATE_CONNECTION_STRING }}
+      AIO_FASTLY_TOKEN: ${{ secrets.AIO_FASTLY_TOKEN }}
+      AIO_FASTLY_PROD_URL: ${{ secrets.AIO_FASTLY_PROD_URL }}
+      AIO_FASTLY_DEV_URL: ${{ secrets.AIO_FASTLY_DEV_URL }}
     with:
       env: prod
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,6 +15,7 @@ on:
 
 jobs:
   set-state:
+    if: github.repository_owner != 'AdobeDocsPrivate'
     runs-on: ubuntu-latest
     outputs:
       path_prefix: ${{ steps.get_path_prefix.outputs.path_prefix }}
@@ -58,6 +59,7 @@ jobs:
 
   echo-state:
     needs: [set-state]
+    if: github.repository_owner != 'AdobeDocsPrivate'
     runs-on: ubuntu-latest
     steps:
       - run: echo "Deploy to stage - ${{ needs.set-state.outputs.deploy_stage }}"
@@ -69,11 +71,26 @@ jobs:
       - run: echo "Base Sha - ${{ needs.set-state.outputs.base_Sha }}"
       - run: echo "Deploy All - ${{ needs.set-state.outputs.deploy_All }}"
 
+  private-deployment-stg:
+    if: github.repository_owner == 'AdobeDocsPrivate' && contains(inputs.env, 'stage')
+    uses: ./.github/workflows/private-deploy.yml
+    secrets: inherit
+    with:
+      env: stg
+
+  private-deployment-prod:
+    if: github.repository_owner == 'AdobeDocsPrivate' && contains(inputs.env, 'prod')
+    uses: ./.github/workflows/private-deploy.yml
+    secrets: inherit
+    with:
+      env: prod
+
   deploy:
     defaults:
       run:
         shell: bash
     needs: [set-state]
+    if: github.repository_owner != 'AdobeDocsPrivate'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/private-deploy.yml
+++ b/.github/workflows/private-deploy.yml
@@ -1,25 +1,29 @@
 ---
-name: Production Deployment
+name: Private Deployment
 on:
-  workflow_dispatch:
+  workflow_call:
     inputs:
       env:
         description: "Deploy to (stg|prod)"
         required: true
         default: "stg"
-      clean:
-        description: "Clean cache (yes|no)"
-        required: true
-        default: "no"
+        type: string
 
 jobs:
   matrix_prep:
-    runs-on: ${{ github.event.organization == 'AdobeDocsPrivate' && (contains(github.event.inputs.env, 'prod') && 'developer-website-arc-prd-runners' || 'developer-website-arc-stg-runners') || 'ubuntu-latest' }}
+    if: github.repository_owner == 'AdobeDocsPrivate'
+    runs-on: ${{ github.repository_owner == 'AdobeDocsPrivate' && (contains(inputs.env, 'prod') && 'developer-website-arc-prd-runners' || 'developer-website-arc-stg-runners') || 'ubuntu-latest' }}
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Checkout adp-devsite-workflow for runner matrix
+        uses: actions/checkout@v4
+        with:
+          repository: AdobeDocs/adp-devsite-workflow
+          path: _workflow-config
 
       - name: Set Matrix
         id: set-matrix
@@ -28,10 +32,10 @@ jobs:
           echo "MATRIX PREPARATION"
           echo "================================================"
           echo "Organization: ${{ github.repository_owner }}"
-          echo "Environment: ${{ github.event.inputs.env }}"
-          
+          echo "Environment: ${{ inputs.env }}"
+
           # Load the JSON data
-          matrix=$(jq --arg org "${{ github.repository_owner }}" --arg env "${{ github.event.inputs.env }}" '[.[] | select(.org == $org and .env == $env)]' .github/matrix/runner_matrix.json)
+          matrix=$(jq --arg org "${{ github.repository_owner }}" --arg env "${{ inputs.env }}" '[.[] | select(.org == $org and .env == $env)]' _workflow-config/.github/matrix/runner_matrix.json)
 
           # Set the formatted matrix as an output
           echo "matrix={\"include\":$(echo $matrix)}" >> $GITHUB_OUTPUT
@@ -44,9 +48,9 @@ jobs:
     strategy:
       matrix: ${{fromJson(needs.matrix_prep.outputs.matrix)}}
     outputs:
-      deploy_prod: ${{ contains(github.event.inputs.env, 'prod') }}
-      deploy_stg: ${{ contains(github.event.inputs.env, 'stg') }}
-      clean_cache: ${{ contains(github.event.inputs.clean, 'yes') }}
+      deploy_prod: ${{ contains(inputs.env, 'prod') }}
+      deploy_stg: ${{ contains(inputs.env, 'stg') }}
+      clean_cache: ${{ contains(inputs.env, 'yes') }}
       path_prefix: ${{ steps.get_path_prefix.outputs.path_prefix }}
       branch_short_ref: ${{ steps.get_branch.outputs.branch }}
 
@@ -85,7 +89,6 @@ jobs:
       - run: echo "Repository name - ${{ github.event.repository.name }}"
       - run: echo "Repository branch - ${{ needs.set-state.outputs.branch_short_ref }}"
       - run: echo "Path prefix - ${{ needs.set-state.outputs.path_prefix }}"
-      - run: echo "Connection string - ${{ needs.set-state.outputs.connection_string }}"
 
   pre-build:
     needs: [set-state, matrix_prep]
@@ -98,7 +101,7 @@ jobs:
 
     steps:
       - name: Check stage Private Azure connection string
-        if: needs.set-state.outputs.deploy_stg == 'true' && github.event.organization == 'AdobeDocsPrivate' && env.AIO_AZURE_DEV_PRIVATE_CONNECTION_STRING == null
+        if: needs.set-state.outputs.deploy_stg == 'true' && env.AIO_AZURE_DEV_PRIVATE_CONNECTION_STRING == null
         run: |
           echo "::error::Please set the Azure Blob Storage connection string as AIO_AZURE_DEV_PRIVATE_CONNECTION_STRING in Github Secrets"
           exit 1
@@ -106,28 +109,12 @@ jobs:
           AIO_AZURE_DEV_PRIVATE_CONNECTION_STRING: ${{ secrets.AIO_AZURE_DEV_PRIVATE_CONNECTION_STRING }}
 
       - name: Check prod Private Azure connection string
-        if: needs.set-state.outputs.deploy_prod == 'true' && github.event.organization == 'AdobeDocsPrivate' && env.AIO_AZURE_PROD_PRIVATE_CONNECTION_STRING == null
+        if: needs.set-state.outputs.deploy_prod == 'true' && env.AIO_AZURE_PROD_PRIVATE_CONNECTION_STRING == null
         run: |
           echo "::error::Please set the Azure Blob Storage connection string as AIO_AZURE_PROD_PRIVATE_CONNECTION_STRING in Github Secrets"
           exit 1
         env:
           AIO_AZURE_PROD_PRIVATE_CONNECTION_STRING: ${{ secrets.AIO_AZURE_PROD_PRIVATE_CONNECTION_STRING }}
-
-      - name: Check stage Azure connection string
-        if: needs.set-state.outputs.deploy_stg == 'true' && github.event.organization == 'AdobeDocs' && env.AIO_AZURE_DEV_CONNECTION_STRING == null
-        run: |
-          echo "::error::Please set the Azure Blob Storage connection string as AIO_AZURE_DEV_CONNECTION_STRING in Github Secrets"
-          exit 1
-        env:
-          AIO_AZURE_DEV_CONNECTION_STRING: ${{ secrets.AIO_AZURE_DEV_CONNECTION_STRING }}
-
-      - name: Check prod Azure connection string
-        if: needs.set-state.outputs.deploy_prod == 'true' && github.event.organization == 'AdobeDocs' && env.AIO_AZURE_PROD_CONNECTION_STRING == null
-        run: |
-          echo "::error::Please set the Azure Blob Storage connection string as AIO_AZURE_PROD_CONNECTION_STRING in Github Secrets"
-          exit 1
-        env:
-          AIO_AZURE_PROD_CONNECTION_STRING: ${{ secrets.AIO_AZURE_PROD_CONNECTION_STRING }}
 
   build:
     defaults:
@@ -147,29 +134,19 @@ jobs:
         env:
           AIO_AZURE_DEV_PRIVATE_CONNECTION_STRING: ${{ secrets.AIO_AZURE_DEV_PRIVATE_CONNECTION_STRING }}
           AIO_AZURE_PROD_PRIVATE_CONNECTION_STRING: ${{ secrets.AIO_AZURE_PROD_PRIVATE_CONNECTION_STRING }}
-          AIO_AZURE_DEV_CONNECTION_STRING: ${{ secrets.AIO_AZURE_DEV_CONNECTION_STRING }}
-          AIO_AZURE_PROD_CONNECTION_STRING: ${{ secrets.AIO_AZURE_PROD_CONNECTION_STRING }}
         with:
           result-encoding: string
           script: |
             console.log('================================================');
             console.log('SELECTING AZURE CONNECTION STRING');
             console.log('================================================');
-            
-            const org = context.payload.organization.login;
-            const isProd = context.payload.inputs.env === 'prod';
-            const isPrivate = org === 'AdobeDocsPrivate';
-            
-            console.log(`Organization: ${org} (${isPrivate ? 'Private' : 'Public'})`);
-            console.log(`Environment: ${isProd ? 'Production' : 'Staging'}`);
-            
-            let connectionString = '';
 
-            if (isPrivate) {
-              connectionString = isProd ? process.env.AIO_AZURE_PROD_PRIVATE_CONNECTION_STRING : process.env.AIO_AZURE_DEV_PRIVATE_CONNECTION_STRING;
-            } else {
-              connectionString = isProd ? process.env.AIO_AZURE_PROD_CONNECTION_STRING : process.env.AIO_AZURE_DEV_CONNECTION_STRING;
-            }
+            const isProd = '${{ inputs.env }}' === 'prod';
+            console.log(`Environment: ${isProd ? 'Production' : 'Staging'}`);
+
+            const connectionString = isProd
+              ? process.env.AIO_AZURE_PROD_PRIVATE_CONNECTION_STRING
+              : process.env.AIO_AZURE_DEV_PRIVATE_CONNECTION_STRING;
 
             console.log('✓ Connection string selected');
             return connectionString;

--- a/.github/workflows/private-deploy.yml
+++ b/.github/workflows/private-deploy.yml
@@ -1,0 +1,482 @@
+---
+name: Production Deployment
+on:
+  workflow_dispatch:
+    inputs:
+      env:
+        description: "Deploy to (stg|prod)"
+        required: true
+        default: "stg"
+      clean:
+        description: "Clean cache (yes|no)"
+        required: true
+        default: "no"
+
+jobs:
+  matrix_prep:
+    runs-on: ${{ github.event.organization == 'AdobeDocsPrivate' && (contains(github.event.inputs.env, 'prod') && 'developer-website-arc-prd-runners' || 'developer-website-arc-stg-runners') || 'ubuntu-latest' }}
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set Matrix
+        id: set-matrix
+        run: |
+          echo "================================================"
+          echo "MATRIX PREPARATION"
+          echo "================================================"
+          echo "Organization: ${{ github.repository_owner }}"
+          echo "Environment: ${{ github.event.inputs.env }}"
+          
+          # Load the JSON data
+          matrix=$(jq --arg org "${{ github.repository_owner }}" --arg env "${{ github.event.inputs.env }}" '[.[] | select(.org == $org and .env == $env)]' .github/matrix/runner_matrix.json)
+
+          # Set the formatted matrix as an output
+          echo "matrix={\"include\":$(echo $matrix)}" >> $GITHUB_OUTPUT
+          echo "✓ Matrix configuration loaded"
+
+  set-state:
+    needs: matrix_prep
+    runs-on:
+      labels: ${{ matrix.runner }}
+    strategy:
+      matrix: ${{fromJson(needs.matrix_prep.outputs.matrix)}}
+    outputs:
+      deploy_prod: ${{ contains(github.event.inputs.env, 'prod') }}
+      deploy_stg: ${{ contains(github.event.inputs.env, 'stg') }}
+      clean_cache: ${{ contains(github.event.inputs.clean, 'yes') }}
+      path_prefix: ${{ steps.get_path_prefix.outputs.path_prefix }}
+      branch_short_ref: ${{ steps.get_branch.outputs.branch }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Get pathPrefix
+        id: get_path_prefix
+        run: |
+          echo "================================================"
+          echo "EXTRACTING PATH PREFIX FROM CONFIG"
+          echo "================================================"
+          
+          # Extract pathPrefix from config.md
+          path_prefix=$(grep -A 1 "^- pathPrefix:" src/pages/config.md | tail -n 1 | sed 's/^[[:space:]]*-[[:space:]]*//' | tr -d '/')
+          echo "path_prefix=/${path_prefix}" >> $GITHUB_OUTPUT
+          
+          echo "✓ Path prefix extracted: /${path_prefix}"
+      - name: Get branch name
+        shell: bash
+        run: echo "##[set-output name=branch;]${GITHUB_REF#refs/heads/}"
+        id: get_branch
+
+  echo-state:
+    needs: [set-state, matrix_prep]
+    runs-on:
+      labels: ${{ matrix.runner }}
+    strategy:
+      matrix: ${{fromJson(needs.matrix_prep.outputs.matrix)}}
+    steps:
+      - run: echo "Deploy to stg - ${{ needs.set-state.outputs.deploy_stg }}"
+      - run: echo "Deploy to prod - ${{ needs.set-state.outputs.deploy_prod }}"
+      - run: echo "Clean cache - ${{ needs.set-state.outputs.clean_cache }}"
+      - run: echo "Repository org - ${{ github.event.repository.owner.login }}"
+      - run: echo "Repository name - ${{ github.event.repository.name }}"
+      - run: echo "Repository branch - ${{ needs.set-state.outputs.branch_short_ref }}"
+      - run: echo "Path prefix - ${{ needs.set-state.outputs.path_prefix }}"
+      - run: echo "Connection string - ${{ needs.set-state.outputs.connection_string }}"
+
+  pre-build:
+    needs: [set-state, matrix_prep]
+
+    runs-on:
+      labels: ${{ matrix.runner }}
+
+    strategy:
+      matrix: ${{fromJson(needs.matrix_prep.outputs.matrix)}}
+
+    steps:
+      - name: Check stage Private Azure connection string
+        if: needs.set-state.outputs.deploy_stg == 'true' && github.event.organization == 'AdobeDocsPrivate' && env.AIO_AZURE_DEV_PRIVATE_CONNECTION_STRING == null
+        run: |
+          echo "::error::Please set the Azure Blob Storage connection string as AIO_AZURE_DEV_PRIVATE_CONNECTION_STRING in Github Secrets"
+          exit 1
+        env:
+          AIO_AZURE_DEV_PRIVATE_CONNECTION_STRING: ${{ secrets.AIO_AZURE_DEV_PRIVATE_CONNECTION_STRING }}
+
+      - name: Check prod Private Azure connection string
+        if: needs.set-state.outputs.deploy_prod == 'true' && github.event.organization == 'AdobeDocsPrivate' && env.AIO_AZURE_PROD_PRIVATE_CONNECTION_STRING == null
+        run: |
+          echo "::error::Please set the Azure Blob Storage connection string as AIO_AZURE_PROD_PRIVATE_CONNECTION_STRING in Github Secrets"
+          exit 1
+        env:
+          AIO_AZURE_PROD_PRIVATE_CONNECTION_STRING: ${{ secrets.AIO_AZURE_PROD_PRIVATE_CONNECTION_STRING }}
+
+      - name: Check stage Azure connection string
+        if: needs.set-state.outputs.deploy_stg == 'true' && github.event.organization == 'AdobeDocs' && env.AIO_AZURE_DEV_CONNECTION_STRING == null
+        run: |
+          echo "::error::Please set the Azure Blob Storage connection string as AIO_AZURE_DEV_CONNECTION_STRING in Github Secrets"
+          exit 1
+        env:
+          AIO_AZURE_DEV_CONNECTION_STRING: ${{ secrets.AIO_AZURE_DEV_CONNECTION_STRING }}
+
+      - name: Check prod Azure connection string
+        if: needs.set-state.outputs.deploy_prod == 'true' && github.event.organization == 'AdobeDocs' && env.AIO_AZURE_PROD_CONNECTION_STRING == null
+        run: |
+          echo "::error::Please set the Azure Blob Storage connection string as AIO_AZURE_PROD_CONNECTION_STRING in Github Secrets"
+          exit 1
+        env:
+          AIO_AZURE_PROD_CONNECTION_STRING: ${{ secrets.AIO_AZURE_PROD_CONNECTION_STRING }}
+
+  build:
+    defaults:
+      run:
+        shell: bash
+    needs: [set-state, pre-build, matrix_prep]
+    runs-on:
+      labels: ${{ matrix.runner }}
+    strategy:
+      matrix: ${{fromJson(needs.matrix_prep.outputs.matrix)}}
+    outputs:
+      build_output_dir: ${{ steps.set_build_output.outputs.build_output_dir }}
+    steps:
+      - name: Select Connection String
+        id: select_connection_string
+        uses: actions/github-script@v6
+        env:
+          AIO_AZURE_DEV_PRIVATE_CONNECTION_STRING: ${{ secrets.AIO_AZURE_DEV_PRIVATE_CONNECTION_STRING }}
+          AIO_AZURE_PROD_PRIVATE_CONNECTION_STRING: ${{ secrets.AIO_AZURE_PROD_PRIVATE_CONNECTION_STRING }}
+          AIO_AZURE_DEV_CONNECTION_STRING: ${{ secrets.AIO_AZURE_DEV_CONNECTION_STRING }}
+          AIO_AZURE_PROD_CONNECTION_STRING: ${{ secrets.AIO_AZURE_PROD_CONNECTION_STRING }}
+        with:
+          result-encoding: string
+          script: |
+            console.log('================================================');
+            console.log('SELECTING AZURE CONNECTION STRING');
+            console.log('================================================');
+            
+            const org = context.payload.organization.login;
+            const isProd = context.payload.inputs.env === 'prod';
+            const isPrivate = org === 'AdobeDocsPrivate';
+            
+            console.log(`Organization: ${org} (${isPrivate ? 'Private' : 'Public'})`);
+            console.log(`Environment: ${isProd ? 'Production' : 'Staging'}`);
+            
+            let connectionString = '';
+
+            if (isPrivate) {
+              connectionString = isProd ? process.env.AIO_AZURE_PROD_PRIVATE_CONNECTION_STRING : process.env.AIO_AZURE_DEV_PRIVATE_CONNECTION_STRING;
+            } else {
+              connectionString = isProd ? process.env.AIO_AZURE_PROD_CONNECTION_STRING : process.env.AIO_AZURE_DEV_CONNECTION_STRING;
+            }
+
+            console.log('✓ Connection string selected');
+            return connectionString;
+
+      - name: Checkout content repo
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.branch }}
+          path: content
+
+      - name: Read site config
+        id: config
+        run: |
+          # Use pathPrefix from set-state job
+          SITE_PATH="${{ needs.set-state.outputs.path_prefix }}"
+          
+          # Strip leading and trailing slashes if present
+          SITE_PATH=$(echo "$SITE_PATH" | sed 's|^/||' | sed 's|/$||')
+
+          # Extract first path segment for prefix
+          SITE_PREFIX=$(echo "$SITE_PATH" | cut -d'/' -f1)
+          echo "SITE_PATH=$SITE_PATH" >> $GITHUB_ENV
+          echo "SITE_PREFIX=$SITE_PREFIX" >> $GITHUB_ENV
+          echo "site_path=$SITE_PATH" >> $GITHUB_OUTPUT
+          echo "✓ Site path validated: $SITE_PATH (prefix: $SITE_PREFIX)"
+
+      - name: Clone adp-devsite
+        uses: actions/checkout@v4
+        with:
+          repository: AdobeDocs/adp-devsite
+          ref: secure-private-config
+          path: adp-devsite
+
+      - name: Clone devsite-runtime-connector
+        uses: actions/checkout@v4
+        with:
+          repository: aemsites/devsite-runtime-connector
+          path: devsite-runtime-connector
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "lts/jod"
+
+      - name: Install dependencies
+        run: |
+          cd content && npm install
+          cd ../adp-devsite && npm install
+          cd ../devsite-runtime-connector && npm install
+
+      - name: Start development servers
+        run: |
+          ROOT_DIR=$(pwd)
+          
+          # Start content server (port 3003)
+          (cd "$ROOT_DIR/content" && npm run dev > "$ROOT_DIR/content-server.log" 2>&1) &
+          echo $! > /tmp/content.pid
+          
+          # Start adp-devsite (port 3000)
+          (cd "$ROOT_DIR/adp-devsite" && npm run dev > "$ROOT_DIR/devsite-server.log" 2>&1) &
+          echo $! > /tmp/devsite.pid
+          
+          # Start runtime connector (port 3001)
+          (cd "$ROOT_DIR/devsite-runtime-connector" && npm run dev > "$ROOT_DIR/connector-server.log" 2>&1) &
+          echo $! > /tmp/connector.pid
+          
+          echo "Servers starting in background..."
+
+      - name: Wait for servers to be ready
+        run: |
+          echo "Waiting for servers..."
+          for port in 3000 3003; do
+            for i in {1..60}; do
+              if curl -s "http://localhost:$port" > /dev/null 2>&1; then
+                echo "✓ Port $port is ready"
+                break
+              fi
+              if [ $i -eq 60 ]; then
+                echo "✗ Port $port timeout"
+                cat content-server.log devsite-server.log connector-server.log 2>/dev/null || true
+                exit 1
+              fi
+              sleep 1
+            done
+          done
+          
+          # Verify site is accessible with retry
+          echo "Verifying site at: http://localhost:3000/${SITE_PATH}/"
+          for i in {1..30}; do
+            HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:3000/${SITE_PATH}/" 2>&1)
+            if [ "$HTTP_CODE" = "200" ]; then
+              echo "✓ Site is accessible (HTTP $HTTP_CODE)"
+              break
+            fi
+            if [ $i -eq 30 ]; then
+              echo "✗ Site verification failed (HTTP $HTTP_CODE)"
+              echo "=== Content Server Log ==="
+              tail -100 content-server.log 2>/dev/null || echo "No log found"
+              echo "=== DevSite Server Log ==="
+              tail -100 devsite-server.log 2>/dev/null || echo "No log found"
+              echo "=== Connector Server Log ==="
+              tail -100 connector-server.log 2>/dev/null || echo "No log found"
+              exit 1
+            fi
+            echo "Attempt $i: HTTP $HTTP_CODE, retrying..."
+            sleep 2
+          done
+
+      - name: Generate static site with curl
+        run: |
+          ROOT_DIR=$(pwd)
+          mkdir -p "$ROOT_DIR/_site"
+
+          # Generate URL list from markdown files
+          cd "$ROOT_DIR/content"
+          find src/pages -name "*.md" | sed 's|src/pages/||' | sed 's|\.md$||' | sed 's|/index$|/|' | while read path; do
+            echo "http://localhost:3000/${SITE_PATH}/$path"
+          done > "$ROOT_DIR/urls.txt"
+
+          echo "Total URLs: $(wc -l < "$ROOT_DIR/urls.txt" | tr -d ' ')"
+          echo "Sample URLs from urls.txt:"
+          head -5 "$ROOT_DIR/urls.txt"
+          
+          cd "$ROOT_DIR/_site"
+          echo "Output directory: $(pwd)"
+          
+          # Download pages with curl
+          # Only index.html and config.html keep .html extension; all other pages save without extension
+          while IFS= read -r url; do
+            # Extract path from URL and strip SITE_PATH prefix
+            # http://localhost:3000/private-eds/guides/ -> guides/
+            path=$(echo "$url" | sed 's|http://localhost:3000/||' | sed "s|^${SITE_PATH}/||")
+            
+            # Create directory structure and choose output filename
+            if [[ "$path" == */ ]] || [[ -z "$path" ]]; then
+              # Directory index -> index.html
+              mkdir -p "$path"
+              output_file="${path}index.html"
+            elif [[ "$path" == "index" ]]; then
+              # Root index page (e.g. from index.md) -> index.html
+              mkdir -p "$path"
+              output_file="index.html"
+            elif [[ "$path" == "config" ]]; then
+              # Config page -> config.html
+              dir=$(dirname "$path")
+              mkdir -p "$dir"
+              output_file="${path}.html"
+            else
+              # All other pages -> no extension
+              dir=$(dirname "$path")
+              mkdir -p "$dir"
+              output_file="${path}"
+            fi
+            
+            echo "Downloading: $url -> $output_file"
+            curl -sf "$url" -o "$output_file" || echo "Failed to download: $url"
+          done < "$ROOT_DIR/urls.txt"
+          
+          echo "✓ Site generation complete"
+          echo "Contents of _site:"
+          find . -type f | head -20
+
+      - name: Copy static assets
+        run: |
+          cd _site
+          
+          # Copy hlx_statics from adp-devsite source
+          mkdir -p localhost+3000/hlx_statics
+          cp -r ../adp-devsite/hlx_statics/* localhost+3000/hlx_statics/
+          echo "✓ Copied $(find localhost+3000/hlx_statics -type f | wc -l | tr -d ' ') static files"
+
+      - name: Fetch API endpoints
+        run: |
+          cd _site
+          mkdir -p "localhost+3000/${SITE_PATH}"
+          mkdir -p localhost+3000/franklin_assets
+          
+          # Config (for side navigation)
+          curl -sf "http://localhost:3000/${SITE_PATH}/config" -o "localhost+3000/config.plain.html" && echo "✓ config"
+          
+          # Footer
+          curl -sf "http://localhost:3000/franklin_assets/footer.plain.html" -o localhost+3000/franklin_assets/footer.plain.html && echo "✓ footer"
+          
+          # Product index map
+          curl -sf "http://localhost:3000/franklin_assets/product-index-map.json" -o localhost+3000/franklin_assets/product-index-map.json && echo "✓ product-index-map"
+          
+          # Site-wide banner
+          curl -sf "http://localhost:3000/${SITE_PATH}/site-wide-banner.json" -o "localhost+3000/${SITE_PATH}/site-wide-banner.json" || echo "○ site-wide-banner (optional)"
+
+      - name: Organize output structure
+        run: |
+          cd _site
+          
+          # Move content from localhost+3000 to root
+          if [ -d "localhost+3000" ]; then
+            mv localhost+3000/* . 2>/dev/null || true
+            rm -rf localhost+3000
+            echo "✓ Output structure organized"
+          fi
+
+      - name: Fix superhero block images
+        run: |
+          cd _site
+          
+          # The superhero.js expects <picture><img></picture> but we have plain <img>
+          # Wrap superhero images in <picture> elements so the background works
+          if [ -f "${SITE_PATH}/index.html" ]; then
+            # Find <img> tags in superhero blocks and wrap them in <picture>
+            perl -i -0pe 's|(<div class="superhero">.*?<div>\s*)<img ([^>]+)>(.*?</div>\s*</div>)|$1<picture><img $2></picture>$3|gs' "${SITE_PATH}/index.html"
+            echo "✓ Superhero images wrapped in <picture>"
+          fi
+
+      - name: Add security headers
+        run: |
+          cd _site
+          
+          # Content Security Policy to mitigate XSS attacks
+          # - 'self' allows resources from same origin
+          # - 'unsafe-inline' required for the interceptor script and inline styles
+          # - data: allows data URIs for images (used by some frameworks)
+          # - blob: allows blob URIs (used for dynamic content)
+          # - https: restricts external resources to HTTPS only
+          CSP_CONTENT="default-src 'self'; script-src 'self' 'unsafe-inline' https:; style-src 'self' 'unsafe-inline' https:; img-src 'self' data: https:; font-src 'self' https:; connect-src 'self' https:; frame-ancestors 'self';"
+          CSP_TAG="<meta http-equiv=\"Content-Security-Policy\" content=\"${CSP_CONTENT}\">"
+          
+          # X-Content-Type-Options to prevent MIME sniffing
+          XCTO_TAG="<meta http-equiv=\"X-Content-Type-Options\" content=\"nosniff\">"
+          
+          # Referrer-Policy for privacy
+          RP_TAG="<meta name=\"referrer\" content=\"strict-origin-when-cross-origin\">"
+          
+          # Combine security meta tags
+          SECURITY_TAGS="${CSP_TAG}${XCTO_TAG}${RP_TAG}"
+          
+          # Inject security headers into all HTML files (after <head>)
+          # Include both *.html and extensionless page files
+          for htmlfile in $(find . -name "*.html" -type f) $(find "./${SITE_PATH}" -type f ! -name "*.*" 2>/dev/null); do
+            [ -f "$htmlfile" ] || continue
+            if ! grep -q "Content-Security-Policy" "$htmlfile" 2>/dev/null; then
+              perl -i -pe "s|<head>|<head>${SECURITY_TAGS}|" "$htmlfile" 2>/dev/null || true
+            fi
+          done
+          
+          SECURED=$(find "./${SITE_PATH}" \( -name "*.html" -o ! -name "*.*" \) -type f -exec grep -l "Content-Security-Policy" {} \; 2>/dev/null | wc -l | tr -d ' ')
+          echo "✓ Security headers added to $SECURED files"
+
+      - name: Stop servers
+        if: always()
+        run: |
+          for pidfile in /tmp/content.pid /tmp/devsite.pid /tmp/connector.pid; do
+            if [ -f "$pidfile" ]; then
+              kill $(cat "$pidfile") 2>/dev/null || true
+            fi
+          done
+
+      - name: Verify build output
+        id: set_build_output
+        run: |
+          ROOT_DIR=$(pwd)
+          cd _site
+          echo "=== Build Summary ==="
+          echo "Total files: $(find . -type f | wc -l | tr -d ' ')"
+          echo "HTML files: $(find . -name '*.html' | wc -l | tr -d ' ')"
+          
+          if [ ! -d "${SITE_PATH}" ]; then
+            echo "ERROR: No content generated!"
+            exit 1
+          fi
+          
+          # Set build output directory
+          BUILD_OUTPUT_DIR="${ROOT_DIR}/_site"
+          echo "ROOT_DIR=${ROOT_DIR}"
+          echo "Expanded path: ${ROOT_DIR}/_site"
+          echo "build_output_dir=${BUILD_OUTPUT_DIR}" >> $GITHUB_OUTPUT
+          echo "✓ Build output directory: ${BUILD_OUTPUT_DIR}"
+          echo "✓ Build verification passed"
+ 
+      - name: Deploy to Azure
+        uses: AdobeDocs/static-website-deploy@private-eds
+        with:
+          enabled-static-website: "true"
+          source: "_site"
+          target: ${{ needs.set-state.outputs.path_prefix }}
+          connection-string: ${{ steps.select_connection_string.outputs.result }}
+          remove-existing-files: "false"
+
+      - name: Deployment complete
+        run: |
+          echo "✓ Deployment to Azure completed successfully"
+
+      - name: Purge Fastly Cache
+        run: |
+          echo "================================================"
+          echo "PURGING FASTLY CACHE"
+          echo "================================================"
+          echo "URL: ${{ needs.set-state.outputs.deploy_prod == 'true' && secrets.AIO_FASTLY_PROD_URL || secrets.AIO_FASTLY_DEV_URL }}${{ needs.set-state.outputs.path_prefix }}"
+          
+      - name: Purge cache
+        uses: AdobeDocs/gatsby-fastly-purge-action@master
+        with:
+          fastly-token: ${{ secrets.AIO_FASTLY_TOKEN }}
+          fastly-url: "${{ needs.set-state.outputs.deploy_prod == 'true' && secrets.AIO_FASTLY_PROD_URL || secrets.AIO_FASTLY_DEV_URL }}${{ needs.set-state.outputs.path_prefix }}"
+      
+      - name: Cache purge complete
+        run: |
+          echo "✓ Fastly cache purged successfully"
+          echo "================================================"
+          echo "DEPLOYMENT COMPLETE"
+          echo "================================================"
+

--- a/.github/workflows/private-deploy.yml
+++ b/.github/workflows/private-deploy.yml
@@ -318,6 +318,35 @@ jobs:
           cp -r ../adp-devsite/hlx_statics/* localhost+3000/hlx_statics/
           echo "✓ Copied $(find localhost+3000/hlx_statics -type f | wc -l | tr -d ' ') static files"
 
+      - name: Copy spec and data files
+        run: |
+          ROOT_DIR=$(pwd)
+          cd "$ROOT_DIR/_site"
+          COUNT=0
+
+          # Copy JSON/YML/YAML from static/
+          if [ -d "$ROOT_DIR/content/static" ]; then
+            for file in $(find "$ROOT_DIR/content/static" -type f \( -name "*.json" -o -name "*.yml" -o -name "*.yaml" \)); do
+              rel_path="${file#$ROOT_DIR/content/}"
+              mkdir -p "$(dirname "$rel_path")"
+              cp "$file" "$rel_path"
+              echo "  Copied $rel_path"
+              COUNT=$((COUNT + 1))
+            done
+          fi
+
+          # Copy JSON/YML/YAML from src/pages/ (exclude auto-generated files)
+          for file in $(find "$ROOT_DIR/content/src/pages" -type f \( -name "*.json" -o -name "*.yml" -o -name "*.yaml" \) \
+            ! -name "contributors.json" ! -name "adp-site-metadata.json"); do
+            rel_path="${file#$ROOT_DIR/content/src/pages/}"
+            mkdir -p "$(dirname "$rel_path")"
+            cp "$file" "$rel_path"
+            echo "  Copied $rel_path"
+            COUNT=$((COUNT + 1))
+          done
+
+          echo "✓ Copied $COUNT spec/data files"
+
       - name: Fetch API endpoints
         run: |
           cd _site

--- a/.github/workflows/private-deploy.yml
+++ b/.github/workflows/private-deploy.yml
@@ -8,6 +8,17 @@ on:
         required: true
         default: "stg"
         type: string
+    secrets:
+      AIO_AZURE_DEV_PRIVATE_CONNECTION_STRING:
+        required: true
+      AIO_AZURE_PROD_PRIVATE_CONNECTION_STRING:
+        required: true
+      AIO_FASTLY_TOKEN:
+        required: true
+      AIO_FASTLY_PROD_URL:
+        required: true
+      AIO_FASTLY_DEV_URL:
+        required: true
 
 jobs:
   matrix_prep:


### PR DESCRIPTION
## Ticket
https://jira.corp.adobe.com/browse/DEVSITE-2324

## Summary

Centralizes `AdobeDocsPrivate` deployment logic into `adp-devsite-workflow` so that new private content repos can use [dev-docs-template](https://github.com/AdobeDocs/dev-docs-template) instead of the separate [adp-devsite-docs-private-template](https://github.com/AdobeDocsPrivate/adp-devsite-docs-private-template) (which will be archived).

## Changes

- **`private-deploy.yml`** - new reusable workflow for `AdobeDocsPrivate` deployments; adapted from [adp-devsite-docs-private-template/deploy.yml](https://github.com/AdobeDocsPrivate/adp-devsite-docs-private-template/blob/5c29be636e525d375c0c1b47d1d94ce5e568168f/.github/workflows/deploy.yml) with the following changes:
  - [converted to `workflow_call`](https://github.com/AdobeDocs/adp-devsite-workflow/blob/cfdcfd3/.github/workflows/private-deploy.yml#L4) - can only be invoked by another workflow, not triggered manually
  - [secrets declared explicitly](https://github.com/AdobeDocs/adp-devsite-workflow/blob/cfdcfd3/.github/workflows/private-deploy.yml#L11-L21) - required for cross-org reusable workflows
  - [connection string logic simplified to private-only](https://github.com/AdobeDocs/adp-devsite-workflow/blob/cfdcfd3/.github/workflows/private-deploy.yml#L142-L163) - removed `AdobeDocs` org branching since this workflow only runs for `AdobeDocsPrivate`
  - [runner matrix read from `adp-devsite-workflow`](https://github.com/AdobeDocs/adp-devsite-workflow/blob/cfdcfd3/.github/workflows/private-deploy.yml#L33-L49) instead of the calling repo - private content repos using `dev-docs-template` won't have `runner_matrix.json` locally
  - [`Copy spec and data files` step added](https://github.com/AdobeDocs/adp-devsite-workflow/blob/cfdcfd3/.github/workflows/private-deploy.yml#L332-L360)
- **`.github/matrix/runner_matrix.json`** - copied from [adp-devsite-docs-private-template](https://github.com/AdobeDocsPrivate/adp-devsite-docs-private-template/blob/5c29be636e525d375c0c1b47d1d94ce5e568168f/.github/matrix/runner_matrix.json)
- **`deploy.yml`** - routes to [private-deployment-stg](https://github.com/AdobeDocs/adp-devsite-workflow/blob/cfdcfd3/.github/workflows/deploy.yml#L85-L95) and [private-deployment-prod](https://github.com/AdobeDocs/adp-devsite-workflow/blob/cfdcfd3/.github/workflows/deploy.yml#L97-L107) jobs when `github.repository_owner == 'AdobeDocsPrivate'`; secrets explicitly passed to both jobs; `AdobeDocs` org jobs unchanged

## Notes

- Existing `AdobeDocsPrivate` content repos ([firefly-beta](https://github.com/AdobeDocsPrivate/firefly-beta/blob/51a3f3a3c93c6c44cd88fd92a525ae74387a3cca/.github/workflows/deploy.yml), [ucm-api](https://github.com/AdobeDocsPrivate/ucm-api/blob/fe2478bdf88658810fc46cefa7dc42507ac38307/.github/workflows/deploy.yml), [express-add-ons-docs-beta](https://github.com/AdobeDocsPrivate/express-add-ons-docs-beta/blob/bb2858dfc3c58117582d3abdcd99e8e8f5c56a5f/.github/workflows/deploy.yml)) are unaffected - their inline `deploy.yml` does not call `adp-devsite-workflow`
- Migration to [dev-docs-template](https://github.com/AdobeDocs/dev-docs-template) is optional for existing private repos
- `secrets: inherit` does not work cross-org (`AdobeDocsPrivate` → `AdobeDocs`) - migrating repos must explicitly pass Azure and Fastly secrets in their `deploy.yml`/`stage.yml` ([failing run](https://github.com/AdobeDocsPrivate/adp-dev-docs-private/actions/runs/24214214861/job/70690702676))

## Testing

| Repo org | Scenario | Trigger | Expected | Screenshot |
|---|---|---|---|---|
| `AdobeDocs` | prod | `deploy.yml` with `env=prod` | Private jobs skipped | https://github.com/AdobeDocs/adp-devsite-branch-protection-test/actions/runs/24221269967/job/70713099818 <img width="1728" height="1045" alt="Screenshot 2026-04-09 at 6 17 34 PM" src="https://github.com/user-attachments/assets/197c8c2f-c4ac-416f-a82f-b50606482be6" /> |
| `AdobeDocs` | stage | `stage.yml` | Private jobs skipped | https://github.com/AdobeDocs/adp-devsite-branch-protection-test/actions/runs/24221291150/job/70713167772 <img width="1728" height="1044" alt="Screenshot 2026-04-09 at 6 18 54 PM" src="https://github.com/user-attachments/assets/d34d834e-f219-436d-a867-20abc21eeeda" />|
| `AdobeDocs` | stage & prod | `deploy.yml` with `env=stage & prod` | Private jobs skipped | https://github.com/AdobeDocs/adp-devsite-branch-protection-test/actions/runs/24221322914/job/70713270457 <img width="1728" height="1044" alt="Screenshot 2026-04-09 at 6 59 24 PM" src="https://github.com/user-attachments/assets/68600cc6-8d07-4e42-9643-1aa462d39814" /> |
| `AdobeDocsPrivate` | stage | `stage.yml` | `private-deployment-stg` runs, prod skipped | https://github.com/AdobeDocsPrivate/adp-dev-docs-private/actions/runs/24221446099/job/70713670948 <img width="1728" height="1044" alt="Screenshot 2026-04-09 at 7 02 33 PM" src="https://github.com/user-attachments/assets/6cdb02c1-ae4b-4773-b7db-ff0a81d53057" /> |
| `AdobeDocsPrivate` | prod | `deploy.yml` with `env=prod` | `private-deployment-prod` runs, stg skipped | https://github.com/AdobeDocsPrivate/adp-dev-docs-private/actions/runs/24221369052/job/70713500303 <img width="1728" height="1046" alt="Screenshot 2026-04-09 at 8 07 27 PM" src="https://github.com/user-attachments/assets/35b9d7ec-52fb-4153-842b-338c6ee3fe92" /> |
| `AdobeDocsPrivate` | stage & prod | `deploy.yml` with `env=stage & prod` | Both private jobs run in parallel | https://github.com/AdobeDocsPrivate/adp-dev-docs-private/actions/runs/24221390550/job/70713504404 <img width="1728" height="1046" alt="Screenshot 2026-04-09 at 8 07 47 PM" src="https://github.com/user-attachments/assets/23dcd976-1191-4872-8f43-9309d38ee9db" /> https://github.com/AdobeDocsPrivate/adp-dev-docs-private/actions/runs/24221390550/job/70713682607 <img width="1728" height="1043" alt="Screenshot 2026-04-09 at 8 08 00 PM" src="https://github.com/user-attachments/assets/4e065873-b728-4c39-a9b5-038583ffc2d3" /> |
