### PR TITLE
Fix build-site-metadata handling for forked PRs

### DIFF
--- a/.github/workflows/build-site-metadata.yml
+++ b/.github/workflows/build-site-metadata.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.event.pull_request.head.repo.fork && github.sha || github.head_ref }}
 
       - name: Build Site Metadata
         run: npx --yes github:AdobeDocs/adp-devsite-utils buildSiteMetadata -v
@@ -27,8 +27,13 @@ jobs:
             echo "changed=true" >> $GITHUB_OUTPUT
           fi
 
+      - name: Recommend building metadata locally
+        if: github.event.pull_request.head.repo.fork == true && steps.check_changes.outputs.changed == 'true'
+        run: |
+          echo "::warning::This PR is from a fork. Please run 'npm run buildSiteMetadata' locally and commit the updated src/pages/adp-site-metadata.json file."
+
       - name: Commit and push if changed
-        if: steps.check_changes.outputs.changed == 'true'
+        if: steps.check_changes.outputs.changed == 'true' && github.event.pull_request.head.repo.full_name == github.repository
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/build-site-metadata.yml
+++ b/.github/workflows/build-site-metadata.yml
@@ -22,6 +22,10 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add src/pages/adp-site-metadata.json
-          git diff --cached --quiet || git commit -m "Generate site metadata"
+          if git diff --cached --quiet; then
+            echo "No changes to commit, skipping commit and push"
+            exit 0
+          fi
+          git commit -m "Generate site metadata"
           git pull --rebase
           git push

--- a/.github/workflows/build-site-metadata.yml
+++ b/.github/workflows/build-site-metadata.yml
@@ -30,7 +30,8 @@ jobs:
       - name: Recommend building metadata locally
         if: github.event.pull_request.head.repo.fork == true && steps.check_changes.outputs.changed == 'true'
         run: |
-          echo "::warning::This PR is from a fork. Please run 'npm run buildSiteMetadata' locally and commit the updated src/pages/adp-site-metadata.json file."
+          echo "::error::This PR is from a fork. Please run 'npm run buildSiteMetadata' locally and commit the updated src/pages/adp-site-metadata.json file."
+          exit 1
 
       - name: Commit and push if changed
         if: steps.check_changes.outputs.changed == 'true' && github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/build-site-metadata.yml
+++ b/.github/workflows/build-site-metadata.yml
@@ -17,15 +17,22 @@ jobs:
       - name: Build Site Metadata
         run: npx --yes github:AdobeDocs/adp-devsite-utils buildSiteMetadata -v
 
+      - name: Check for changes
+        id: check_changes
+        run: |
+          if git diff --quiet HEAD -- src/pages/adp-site-metadata.json; then
+            echo "No changes to commit, skipping commit and push"
+            echo "changed=false" >> $GITHUB_OUTPUT
+          else
+            echo "changed=true" >> $GITHUB_OUTPUT
+          fi
+
       - name: Commit and push if changed
+        if: steps.check_changes.outputs.changed == 'true'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add src/pages/adp-site-metadata.json
-          if git diff --cached --quiet; then
-            echo "No changes to commit, skipping commit and push"
-            exit 0
-          fi
           git commit -m "Generate site metadata"
           git pull --rebase
           git push


### PR DESCRIPTION
## Purpose of this pull request

This pull request updates the site metadata workflow to handle forked pull requests more safely and predictably, based on behavior reproduced in [AdobeDocs/commerce-php#443](https://github.com/AdobeDocs/commerce-php/pull/443) and [AdobeDocs/commerce-php#444](https://github.com/AdobeDocs/commerce-php/pull/444).

## Summary

- Check out the correct ref for forked PRs so metadata generation runs against the submitted changes
- Detect whether `src/pages/adp-site-metadata.json` actually changed before attempting any commit or push
- Prevent the workflow from trying to push back to forked repositories, and surface a clear error telling contributors to run `npm run buildSiteMetadata` locally when metadata updates are needed
- Avoid unnecessary empty commit attempts when metadata output is unchanged

## Testing

- Verified the branch diff only changes `.github/workflows/build-site-metadata.yml`
- Confirmed the workflow now gates commit/push behavior on actual metadata changes
- Confirmed forked PRs fail with actionable guidance instead of attempting an automated push
- Validated related workflow behavior against [AdobeDocs/commerce-php#443](https://github.com/AdobeDocs/commerce-php/pull/443) for forked-PR testing and [AdobeDocs/commerce-php#444](https://github.com/AdobeDocs/commerce-php/pull/444) for same-repo PR testing