### PR TITLE
feat: v2 workflows

### DIFF
--- a/.github/workflows/build-auto-generated-files-v2.yml
+++ b/.github/workflows/build-auto-generated-files-v2.yml
@@ -2,12 +2,28 @@
 name: Build Auto-Generated Files
 on:
   workflow_call:
+    inputs:
+      baseSha:
+        type: string
+        required: false
+      buildAll:
+        type: boolean
+        required: false
+        default: false
+    secrets:
+      ADP_DEVSITE_APP_ID:
+        required: true
+      ADP_DEVSITE_APP_PRIVATE_KEY:
+        required: true
 
 jobs:
   build-contributors:
     name: Build Contributors
     if: github.repository != 'AdobeDocs/dev-docs-template'
-    uses: ./.github/workflows/build-contributors.yml
+    uses: ./.github/workflows/build-contributors-v2.yml
+    with:
+      baseSha: ${{ inputs.baseSha }}
+      buildAll: ${{ inputs.buildAll }}
     secrets: inherit
 
   build-site-metadata:
@@ -16,4 +32,5 @@ jobs:
     if: |
       always() &&
       github.repository != 'AdobeDocs/dev-docs-template'
-    uses: ./.github/workflows/build-site-metadata.yml
+    uses: ./.github/workflows/build-site-metadata-v2.yml
+    secrets: inherit

--- a/.github/workflows/build-auto-generated-files-v2.yml
+++ b/.github/workflows/build-auto-generated-files-v2.yml
@@ -1,0 +1,19 @@
+---
+name: Build Auto-Generated Files
+on:
+  workflow_call:
+
+jobs:
+  build-contributors:
+    name: Build Contributors
+    if: github.repository != 'AdobeDocs/dev-docs-template'
+    uses: ./.github/workflows/build-contributors.yml
+    secrets: inherit
+
+  build-site-metadata:
+    name: Build Site Metadata
+    needs: build-contributors
+    if: |
+      always() &&
+      github.repository != 'AdobeDocs/dev-docs-template'
+    uses: ./.github/workflows/build-site-metadata.yml

--- a/.github/workflows/build-contributors-v2.yml
+++ b/.github/workflows/build-contributors-v2.yml
@@ -1,0 +1,37 @@
+---
+name: Build Contributors
+on:
+  workflow_call:
+
+jobs:
+  build-contributors:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0
+
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.ADP_DEVSITE_APP_ID }}
+          private-key: ${{ secrets.ADP_DEVSITE_APP_PRIVATE_KEY }}
+
+      - name: Build Contributors
+        run: npx --yes github:AdobeDocs/adp-devsite-utils buildContributors -v
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      - name: Commit and push if changed
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add src/pages/contributors.json
+          git diff --cached --quiet || git commit -m "Generate contributors"
+          git pull --rebase
+          git push

--- a/.github/workflows/build-contributors-v2.yml
+++ b/.github/workflows/build-contributors-v2.yml
@@ -2,6 +2,14 @@
 name: Build Contributors
 on:
   workflow_call:
+    inputs:
+      baseSha:
+        type: string
+        required: false
+      buildAll:
+        type: boolean
+        required: false
+        default: false
 
 jobs:
   build-contributors:
@@ -12,7 +20,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.head_ref }}
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Generate GitHub App token
@@ -23,15 +31,17 @@ jobs:
           private-key: ${{ secrets.ADP_DEVSITE_APP_PRIVATE_KEY }}
 
       - name: Build Contributors
-        run: npx --yes github:AdobeDocs/adp-devsite-utils buildContributors -v
+        run: npx --yes github:AdobeDocs/adp-devsite-utils buildContributorsV2 -v ${{ inputs.buildAll && '--all' || '' }}
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          BASE_SHA: ${{ inputs.baseSha || github.event.before }}
 
       - name: Commit and push if changed
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/${{ github.repository }}
           git add src/pages/contributors.json
-          git diff --cached --quiet || git commit -m "Generate contributors"
-          git pull --rebase
+          git pull
+          git diff --cached --quiet || git commit -m "chore: auto-generate contributors"
           git push

--- a/.github/workflows/build-site-metadata-v2.yml
+++ b/.github/workflows/build-site-metadata-v2.yml
@@ -1,0 +1,27 @@
+---
+name: Build Site Metadata
+on:
+  workflow_call:
+
+jobs:
+  build-site-metadata:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.head_ref }}
+
+      - name: Build Site Metadata
+        run: npx --yes github:AdobeDocs/adp-devsite-utils buildSiteMetadata -v
+
+      - name: Commit and push if changed
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add src/pages/adp-site-metadata.json
+          git diff --cached --quiet || git commit -m "Generate site metadata"
+          git pull --rebase
+          git push

--- a/.github/workflows/build-site-metadata-v2.yml
+++ b/.github/workflows/build-site-metadata-v2.yml
@@ -12,7 +12,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.head_ref }}
+          persist-credentials: false
+
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.ADP_DEVSITE_APP_ID }}
+          private-key: ${{ secrets.ADP_DEVSITE_APP_PRIVATE_KEY }}
 
       - name: Build Site Metadata
         run: npx --yes github:AdobeDocs/adp-devsite-utils buildSiteMetadata -v
@@ -21,7 +28,8 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/${{ github.repository }}
           git add src/pages/adp-site-metadata.json
-          git diff --cached --quiet || git commit -m "Generate site metadata"
-          git pull --rebase
+          git pull
+          git diff --cached --quiet || git commit -m "chore: auto-generate site metadata"
           git push

--- a/.github/workflows/deploy-v2.yml
+++ b/.github/workflows/deploy-v2.yml
@@ -12,34 +12,57 @@ on:
       deployAll:
         type: boolean
         default: false
-    secrets:
-      AIO_AZURE_DEV_PRIVATE_CONNECTION_STRING:
-        required: false
-      AIO_AZURE_PROD_PRIVATE_CONNECTION_STRING:
-        required: false
-      AIO_FASTLY_TOKEN:
-        required: false
-      AIO_FASTLY_PROD_URL:
-        required: false
-      AIO_FASTLY_DEV_URL:
-        required: false
 
 jobs:
+  get-base-sha:
+    runs-on: ubuntu-latest
+    outputs:
+      base_sha: ${{ steps.last_successful_workflow_dispatch_run.outputs.base_sha }}
+    steps:
+      - name: Get last successful workflow_dispatch run
+        id: last_successful_workflow_dispatch_run
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const branch = context.ref.replace('refs/heads/', '');
+            const workflowId = '${{ contains(inputs.env, 'prod') && 'deploy-v2.yml' || 'stage-v2.yml' }}';
+            try {
+              const workflowRuns = await github.rest.actions.listWorkflowRuns({
+                owner,
+                repo,
+                workflow_id: workflowId,
+                branch: branch,
+                event: 'workflow_dispatch',
+                status: 'success',
+                per_page: 1,
+              });
+              if (workflowRuns.data.workflow_runs.length > 0) {
+                core.setOutput('base_sha', workflowRuns.data.workflow_runs[0].head_sha);
+              } else {
+                core.setOutput('base_sha', '');
+              }
+            } catch (error) {
+              console.log(`Error fetching workflow runs: ${error.message}`);
+              core.setOutput('base_sha', '');
+            }
+
   set-state:
-    if: github.repository_owner != 'AdobeDocsPrivate'
+    needs: [get-base-sha]
     runs-on: ubuntu-latest
     outputs:
       path_prefix: ${{ steps.get_path_prefix.outputs.path_prefix }}
       branch_short_ref: ${{ steps.get_branch.outputs.branch }}
       deploy_stage: ${{ contains(inputs.env, 'stage') }}
       deploy_prod: ${{ contains(inputs.env, 'prod') }}
-      base_Sha: ${{ inputs.baseSha }}
-      deploy_All: ${{ inputs.deployAll }}
+      base_sha: ${{ inputs.baseSha || needs.get-base-sha.outputs.base_sha }}
+      deploy_all: ${{ inputs.deployAll }}
+      has_app_secrets: ${{ secrets.ADP_DEVSITE_APP_ID != '' }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-  
+
       - name: Checkout Scripts Repo
         uses: actions/checkout@v6
         with:
@@ -70,7 +93,6 @@ jobs:
 
   echo-state:
     needs: [set-state]
-    if: github.repository_owner != 'AdobeDocsPrivate'
     runs-on: ubuntu-latest
     steps:
       - run: echo "Deploy to stage - ${{ needs.set-state.outputs.deploy_stage }}"
@@ -79,39 +101,26 @@ jobs:
       - run: echo "Repository org - ${{ github.event.repository.owner.login }}"
       - run: echo "Repository name - ${{ github.event.repository.name }}"
       - run: echo "Repository branch - ${{ needs.set-state.outputs.branch_short_ref }}"
-      - run: echo "Base Sha - ${{ needs.set-state.outputs.base_Sha }}"
-      - run: echo "Deploy All - ${{ needs.set-state.outputs.deploy_All }}"
+      - run: echo "Base Sha - ${{ needs.set-state.outputs.base_sha }}"
+      - run: echo "Deploy All - ${{ needs.set-state.outputs.deploy_all }}"
+      - run: echo "Has App Secrets - ${{ needs.set-state.outputs.has_app_secrets }}"
 
-  private-deployment-stg:
-    if: github.repository_owner == 'AdobeDocsPrivate' && contains(inputs.env, 'stage')
-    uses: ./.github/workflows/private-deploy.yml
-    secrets:
-      AIO_AZURE_DEV_PRIVATE_CONNECTION_STRING: ${{ secrets.AIO_AZURE_DEV_PRIVATE_CONNECTION_STRING }}
-      AIO_AZURE_PROD_PRIVATE_CONNECTION_STRING: ${{ secrets.AIO_AZURE_PROD_PRIVATE_CONNECTION_STRING }}
-      AIO_FASTLY_TOKEN: ${{ secrets.AIO_FASTLY_TOKEN }}
-      AIO_FASTLY_PROD_URL: ${{ secrets.AIO_FASTLY_PROD_URL }}
-      AIO_FASTLY_DEV_URL: ${{ secrets.AIO_FASTLY_DEV_URL }}
+  build-auto-generated-files:
+    name: Build Auto-Generated Files
+    needs: [set-state]
+    if: github.repository != 'AdobeDocs/dev-docs-template' && needs.set-state.outputs.has_app_secrets == 'true'
+    uses: ./.github/workflows/build-auto-generated-files-v2.yml
     with:
-      env: stg
-
-  private-deployment-prod:
-    if: github.repository_owner == 'AdobeDocsPrivate' && contains(inputs.env, 'prod')
-    uses: ./.github/workflows/private-deploy.yml
-    secrets:
-      AIO_AZURE_DEV_PRIVATE_CONNECTION_STRING: ${{ secrets.AIO_AZURE_DEV_PRIVATE_CONNECTION_STRING }}
-      AIO_AZURE_PROD_PRIVATE_CONNECTION_STRING: ${{ secrets.AIO_AZURE_PROD_PRIVATE_CONNECTION_STRING }}
-      AIO_FASTLY_TOKEN: ${{ secrets.AIO_FASTLY_TOKEN }}
-      AIO_FASTLY_PROD_URL: ${{ secrets.AIO_FASTLY_PROD_URL }}
-      AIO_FASTLY_DEV_URL: ${{ secrets.AIO_FASTLY_DEV_URL }}
-    with:
-      env: prod
+      baseSha: ${{ needs.set-state.outputs.base_sha }}
+      buildAll: ${{ inputs.deployAll }}
+    secrets: inherit
 
   deploy:
     defaults:
       run:
         shell: bash
-    needs: [set-state]
-    if: github.repository_owner != 'AdobeDocsPrivate'
+    needs: [set-state, build-auto-generated-files]
+    if: always()
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -124,45 +133,15 @@ jobs:
           path: scripts
           ref: main
 
-      - name: Get last successful workflow_dispatch run
-        id: last_successful_workflow_dispatch_run
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const { owner, repo } = context.repo;
-            const branch = '${{ needs.set-state.outputs.branch_short_ref }}';
-            const workflowId = '${{ needs.set-state.outputs.deploy_prod == 'true' && 'deploy.yml' || 'stage.yml' }}';
+      - name: Pull auto-generated file commits
+        run: git pull
 
-            try {
-              const workflowRuns = await github.rest.actions.listWorkflowRuns({
-                owner,
-                repo,
-                workflow_id: workflowId,
-                branch: branch,
-                event: 'workflow_dispatch',
-                status: 'success',
-                per_page: 1, // Only need the latest one
-              });
-
-              if (workflowRuns.data.workflow_runs.length > 0) {
-                const lastSuccessfulRun = workflowRuns.data.workflow_runs[0];
-                console.log(`Last successful workflow_dispatch run on branch '${branch}':`);
-                console.log(`ID: ${lastSuccessfulRun.id}`);
-                console.log(`Commit SHA: ${lastSuccessfulRun.head_sha}`);
-                console.log(`Run URL: ${lastSuccessfulRun.html_url}`);
-                core.setOutput('base', lastSuccessfulRun.head_sha);
-              } else {
-                console.log(`No successful workflow_dispatch runs found on branch '${branch}' for workflow '${workflowId}'.`);
-                core.setOutput('base', '');
-              }
-            } catch (error) {
-              console.log(`Error fetching workflow runs: ${error.message}`);
-              console.log(`Workflow '${workflowId}' may not exist in this repository. Defaulting base to empty string.`);
-              core.setOutput('base', '');
-            }
+      - name: Get head SHA
+        id: get-head-sha
+        run: echo "head_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Get changed files in the src/pages folder
-        if: needs.set-state.outputs.deploy_All == 'false'
+        if: needs.set-state.outputs.deploy_all == 'false'
         id: changed-files-specific
         uses: tj-actions/changed-files@v46.0.5
         with:
@@ -170,10 +149,11 @@ jobs:
           escape_json: false
           files: |
             src/pages/**
-          base_sha: ${{ needs.set-state.outputs.base_Sha || steps.last_successful_workflow_dispatch_run.outputs.base }}
+          sha: ${{ steps.get-head-sha.outputs.head_sha }}
+          base_sha: ${{ needs.set-state.outputs.base_sha }}
 
       - name: Get all files from src/pages folder
-        if: needs.set-state.outputs.deploy_All == 'true'
+        if: needs.set-state.outputs.deploy_all == 'true'
         id: all-files
         uses: actions/github-script@v7
         with:
@@ -185,8 +165,8 @@ jobs:
             const srcFilesFixedPaths = [];
             srcFiles.forEach((path) => {
               let pathSplitter = path.split(`${{ github.event.repository.name }}/src/pages`);
-              if(pathSplitter.length > 1){
-                  srcFilesFixedPaths.push(`src/pages${pathSplitter[1]}`)
+              if (pathSplitter.length > 1) {
+                srcFilesFixedPaths.push(`src/pages${pathSplitter[1]}`);
               }
             });
 
@@ -194,7 +174,7 @@ jobs:
             core.setOutput('all_files', serializedAllFiles);
 
       - name: Deploy only changed files to stage
-        if: needs.set-state.outputs.deploy_stage == 'true' && steps.changed-files-specific.outputs.any_modified == 'true' && needs.set-state.outputs.deploy_All == 'false'
+        if: needs.set-state.outputs.deploy_stage == 'true' && steps.changed-files-specific.outputs.any_modified == 'true' && needs.set-state.outputs.deploy_all == 'false'
         uses: actions/github-script@v7
         with:
           script: |
@@ -211,7 +191,7 @@ jobs:
             });
 
       - name: Force deploy all files to stage
-        if: needs.set-state.outputs.deploy_stage == 'true' && needs.set-state.outputs.deploy_All == 'true'
+        if: needs.set-state.outputs.deploy_stage == 'true' && needs.set-state.outputs.deploy_all == 'true'
         uses: actions/github-script@v7
         with:
           script: |
@@ -233,7 +213,7 @@ jobs:
         shell: bash
 
       - name: Clean cache on only changed files on stage
-        if: needs.set-state.outputs.deploy_stage == 'true' && steps.changed-files-specific.outputs.any_modified == 'true' && needs.set-state.outputs.deploy_All == 'false'
+        if: needs.set-state.outputs.deploy_stage == 'true' && steps.changed-files-specific.outputs.any_modified == 'true' && needs.set-state.outputs.deploy_all == 'false'
         uses: actions/github-script@v7
         with:
           script: |
@@ -250,7 +230,7 @@ jobs:
             });
 
       - name: Clean cache on all files on stage
-        if: needs.set-state.outputs.deploy_stage == 'true' && needs.set-state.outputs.deploy_All == 'true'
+        if: needs.set-state.outputs.deploy_stage == 'true' && needs.set-state.outputs.deploy_all == 'true'
         uses: actions/github-script@v7
         with:
           script: |
@@ -267,7 +247,7 @@ jobs:
             });
 
       - name: Deploy only changed files to prod (Step 1 of 2)
-        if: needs.set-state.outputs.deploy_prod == 'true' && steps.changed-files-specific.outputs.any_modified == 'true' && needs.set-state.outputs.deploy_All == 'false'
+        if: needs.set-state.outputs.deploy_prod == 'true' && steps.changed-files-specific.outputs.any_modified == 'true' && needs.set-state.outputs.deploy_all == 'false'
         uses: actions/github-script@v7
         with:
           script: |
@@ -284,7 +264,7 @@ jobs:
             });
 
       - name: Force deploy all files to prod (Step 1 of 2)
-        if: needs.set-state.outputs.deploy_prod == 'true' && needs.set-state.outputs.deploy_All == 'true'
+        if: needs.set-state.outputs.deploy_prod == 'true' && needs.set-state.outputs.deploy_all == 'true'
         uses: actions/github-script@v7
         with:
           script: |
@@ -306,7 +286,7 @@ jobs:
         shell: bash
 
       - name: Deploy only changed files to prod (Step 2 of 2)
-        if: needs.set-state.outputs.deploy_prod == 'true' && steps.changed-files-specific.outputs.any_modified == 'true' && needs.set-state.outputs.deploy_All == 'false'
+        if: needs.set-state.outputs.deploy_prod == 'true' && steps.changed-files-specific.outputs.any_modified == 'true' && needs.set-state.outputs.deploy_all == 'false'
         uses: actions/github-script@v7
         with:
           script: |
@@ -323,7 +303,7 @@ jobs:
             });
 
       - name: Force deploy all files to prod (Step 2 of 2)
-        if: needs.set-state.outputs.deploy_prod == 'true' && needs.set-state.outputs.deploy_All == 'true'
+        if: needs.set-state.outputs.deploy_prod == 'true' && needs.set-state.outputs.deploy_all == 'true'
         uses: actions/github-script@v7
         with:
           script: |
@@ -345,7 +325,7 @@ jobs:
         shell: bash
 
       - name: Clean cache on only changed files on prod
-        if: needs.set-state.outputs.deploy_prod == 'true' && steps.changed-files-specific.outputs.any_modified == 'true' && needs.set-state.outputs.deploy_All == 'false'
+        if: needs.set-state.outputs.deploy_prod == 'true' && steps.changed-files-specific.outputs.any_modified == 'true' && needs.set-state.outputs.deploy_all == 'false'
         uses: actions/github-script@v7
         with:
           script: |
@@ -372,7 +352,7 @@ jobs:
             });
 
       - name: Clean cache on all files on prod
-        if: needs.set-state.outputs.deploy_prod == 'true' && needs.set-state.outputs.deploy_All == 'true'
+        if: needs.set-state.outputs.deploy_prod == 'true' && needs.set-state.outputs.deploy_all == 'true'
         uses: actions/github-script@v7
         with:
           script: |

--- a/.github/workflows/deploy-v2.yml
+++ b/.github/workflows/deploy-v2.yml
@@ -1,0 +1,399 @@
+---
+name: Deployment
+on:
+  workflow_call:
+    inputs:
+      env:
+        required: true
+        type: string
+      baseSha:
+        type: string
+        required: false
+      deployAll:
+        type: boolean
+        default: false
+    secrets:
+      AIO_AZURE_DEV_PRIVATE_CONNECTION_STRING:
+        required: false
+      AIO_AZURE_PROD_PRIVATE_CONNECTION_STRING:
+        required: false
+      AIO_FASTLY_TOKEN:
+        required: false
+      AIO_FASTLY_PROD_URL:
+        required: false
+      AIO_FASTLY_DEV_URL:
+        required: false
+
+jobs:
+  set-state:
+    if: github.repository_owner != 'AdobeDocsPrivate'
+    runs-on: ubuntu-latest
+    outputs:
+      path_prefix: ${{ steps.get_path_prefix.outputs.path_prefix }}
+      branch_short_ref: ${{ steps.get_branch.outputs.branch }}
+      deploy_stage: ${{ contains(inputs.env, 'stage') }}
+      deploy_prod: ${{ contains(inputs.env, 'prod') }}
+      base_Sha: ${{ inputs.baseSha }}
+      deploy_All: ${{ inputs.deployAll }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+  
+      - name: Checkout Scripts Repo
+        uses: actions/checkout@v6
+        with:
+          repository: AdobeDocs/adp-devsite-scripts
+          path: scripts
+          ref: main
+
+      - name: Get path prefix
+        uses: actions/github-script@v7
+        id: get_path_prefix
+        with:
+          script: |
+            const script = require('./scripts/get-path-prefix.js');
+            script({ core, isStage:"${{ contains(inputs.env, 'stage') }}", isProd:"${{ contains(inputs.env, 'prod') }}" });
+          result-encoding: string
+
+      - name: Get branch name
+        shell: bash
+        run: echo "branch=${GITHUB_REF#refs/heads/}" >> "$GITHUB_OUTPUT"
+        id: get_branch
+
+      - name: Validate branch name
+        if: contains(steps.get_branch.outputs.branch, '/')
+        uses: actions/github-script@v7
+        with:
+          script: |
+            core.setFailed("Branch name '${{ steps.get_branch.outputs.branch }}' contains a slash (/), which is not supported by EDS. Please rename your branch to remove the slash and try again.");
+
+  echo-state:
+    needs: [set-state]
+    if: github.repository_owner != 'AdobeDocsPrivate'
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Deploy to stage - ${{ needs.set-state.outputs.deploy_stage }}"
+      - run: echo "Deploy to prod - ${{ needs.set-state.outputs.deploy_prod }}"
+      - run: echo "Path prefix - ${{ needs.set-state.outputs.path_prefix }}"
+      - run: echo "Repository org - ${{ github.event.repository.owner.login }}"
+      - run: echo "Repository name - ${{ github.event.repository.name }}"
+      - run: echo "Repository branch - ${{ needs.set-state.outputs.branch_short_ref }}"
+      - run: echo "Base Sha - ${{ needs.set-state.outputs.base_Sha }}"
+      - run: echo "Deploy All - ${{ needs.set-state.outputs.deploy_All }}"
+
+  private-deployment-stg:
+    if: github.repository_owner == 'AdobeDocsPrivate' && contains(inputs.env, 'stage')
+    uses: ./.github/workflows/private-deploy.yml
+    secrets:
+      AIO_AZURE_DEV_PRIVATE_CONNECTION_STRING: ${{ secrets.AIO_AZURE_DEV_PRIVATE_CONNECTION_STRING }}
+      AIO_AZURE_PROD_PRIVATE_CONNECTION_STRING: ${{ secrets.AIO_AZURE_PROD_PRIVATE_CONNECTION_STRING }}
+      AIO_FASTLY_TOKEN: ${{ secrets.AIO_FASTLY_TOKEN }}
+      AIO_FASTLY_PROD_URL: ${{ secrets.AIO_FASTLY_PROD_URL }}
+      AIO_FASTLY_DEV_URL: ${{ secrets.AIO_FASTLY_DEV_URL }}
+    with:
+      env: stg
+
+  private-deployment-prod:
+    if: github.repository_owner == 'AdobeDocsPrivate' && contains(inputs.env, 'prod')
+    uses: ./.github/workflows/private-deploy.yml
+    secrets:
+      AIO_AZURE_DEV_PRIVATE_CONNECTION_STRING: ${{ secrets.AIO_AZURE_DEV_PRIVATE_CONNECTION_STRING }}
+      AIO_AZURE_PROD_PRIVATE_CONNECTION_STRING: ${{ secrets.AIO_AZURE_PROD_PRIVATE_CONNECTION_STRING }}
+      AIO_FASTLY_TOKEN: ${{ secrets.AIO_FASTLY_TOKEN }}
+      AIO_FASTLY_PROD_URL: ${{ secrets.AIO_FASTLY_PROD_URL }}
+      AIO_FASTLY_DEV_URL: ${{ secrets.AIO_FASTLY_DEV_URL }}
+    with:
+      env: prod
+
+  deploy:
+    defaults:
+      run:
+        shell: bash
+    needs: [set-state]
+    if: github.repository_owner != 'AdobeDocsPrivate'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Checkout Scripts Repo
+        uses: actions/checkout@v6
+        with:
+          repository: AdobeDocs/adp-devsite-scripts
+          path: scripts
+          ref: main
+
+      - name: Get last successful workflow_dispatch run
+        id: last_successful_workflow_dispatch_run
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const branch = '${{ needs.set-state.outputs.branch_short_ref }}';
+            const workflowId = '${{ needs.set-state.outputs.deploy_prod == 'true' && 'deploy.yml' || 'stage.yml' }}';
+
+            try {
+              const workflowRuns = await github.rest.actions.listWorkflowRuns({
+                owner,
+                repo,
+                workflow_id: workflowId,
+                branch: branch,
+                event: 'workflow_dispatch',
+                status: 'success',
+                per_page: 1, // Only need the latest one
+              });
+
+              if (workflowRuns.data.workflow_runs.length > 0) {
+                const lastSuccessfulRun = workflowRuns.data.workflow_runs[0];
+                console.log(`Last successful workflow_dispatch run on branch '${branch}':`);
+                console.log(`ID: ${lastSuccessfulRun.id}`);
+                console.log(`Commit SHA: ${lastSuccessfulRun.head_sha}`);
+                console.log(`Run URL: ${lastSuccessfulRun.html_url}`);
+                core.setOutput('base', lastSuccessfulRun.head_sha);
+              } else {
+                console.log(`No successful workflow_dispatch runs found on branch '${branch}' for workflow '${workflowId}'.`);
+                core.setOutput('base', '');
+              }
+            } catch (error) {
+              console.log(`Error fetching workflow runs: ${error.message}`);
+              console.log(`Workflow '${workflowId}' may not exist in this repository. Defaulting base to empty string.`);
+              core.setOutput('base', '');
+            }
+
+      - name: Get changed files in the src/pages folder
+        if: needs.set-state.outputs.deploy_All == 'false'
+        id: changed-files-specific
+        uses: tj-actions/changed-files@v46.0.5
+        with:
+          json: true
+          escape_json: false
+          files: |
+            src/pages/**
+          base_sha: ${{ needs.set-state.outputs.base_Sha || steps.last_successful_workflow_dispatch_run.outputs.base }}
+
+      - name: Get all files from src/pages folder
+        if: needs.set-state.outputs.deploy_All == 'true'
+        id: all-files
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const patterns = ['src/pages/**/*.*'];
+            const globberSrcFiles = await glob.create(patterns[0]);
+            const srcFiles = await globberSrcFiles.glob();
+
+            const srcFilesFixedPaths = [];
+            srcFiles.forEach((path) => {
+              let pathSplitter = path.split(`${{ github.event.repository.name }}/src/pages`);
+              if(pathSplitter.length > 1){
+                  srcFilesFixedPaths.push(`src/pages${pathSplitter[1]}`)
+              }
+            });
+
+            const serializedAllFiles = JSON.stringify(srcFilesFixedPaths);
+            core.setOutput('all_files', serializedAllFiles);
+
+      - name: Deploy only changed files to stage
+        if: needs.set-state.outputs.deploy_stage == 'true' && steps.changed-files-specific.outputs.any_modified == 'true' && needs.set-state.outputs.deploy_All == 'false'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const script = require('./scripts/deploy.js');
+
+            await script({
+              core,
+              changes: ${{ steps.changed-files-specific.outputs.all_changed_files }},
+              deletions: ${{ steps.changed-files-specific.outputs.deleted_files }},
+              operation: "preview",
+              siteEnv: "stage",
+              branch: "${{ needs.set-state.outputs.branch_short_ref }}",
+              pathPrefix: "${{ needs.set-state.outputs.path_prefix }}"
+            });
+
+      - name: Force deploy all files to stage
+        if: needs.set-state.outputs.deploy_stage == 'true' && needs.set-state.outputs.deploy_All == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const script = require('./scripts/deploy.js');
+
+            await script({
+              core,
+              changes: ${{ steps.all-files.outputs.all_files }},
+              deletions: [],
+              operation: "preview",
+              siteEnv: "stage",
+              branch: "${{ needs.set-state.outputs.branch_short_ref }}",
+              pathPrefix: "${{ needs.set-state.outputs.path_prefix }}"
+            });
+
+      - name: Sleep for 30 seconds before cleaning stage cache
+        if: needs.set-state.outputs.deploy_stage == 'true'
+        run: sleep 30s
+        shell: bash
+
+      - name: Clean cache on only changed files on stage
+        if: needs.set-state.outputs.deploy_stage == 'true' && steps.changed-files-specific.outputs.any_modified == 'true' && needs.set-state.outputs.deploy_All == 'false'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const script = require('./scripts/deploy.js');
+
+            await script({
+              core,
+              changes: ${{ steps.changed-files-specific.outputs.all_changed_files }},
+              deletions: ${{ steps.changed-files-specific.outputs.deleted_files }},
+              operation: "cache",
+              siteEnv: "stage",
+              branch: "${{ needs.set-state.outputs.branch_short_ref }}",
+              pathPrefix: "${{ needs.set-state.outputs.path_prefix }}"
+            });
+
+      - name: Clean cache on all files on stage
+        if: needs.set-state.outputs.deploy_stage == 'true' && needs.set-state.outputs.deploy_All == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const script = require('./scripts/deploy.js');
+
+            await script({
+              core,
+              changes: ${{ steps.all-files.outputs.all_files }},
+              deletions: [],
+              operation: "cache",
+              siteEnv: "stage",
+              branch: "${{ needs.set-state.outputs.branch_short_ref }}",
+              pathPrefix: "${{ needs.set-state.outputs.path_prefix }}"
+            });
+
+      - name: Deploy only changed files to prod (Step 1 of 2)
+        if: needs.set-state.outputs.deploy_prod == 'true' && steps.changed-files-specific.outputs.any_modified == 'true' && needs.set-state.outputs.deploy_All == 'false'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const script = require('./scripts/deploy.js');
+
+            await script({
+              core,
+              changes: ${{ steps.changed-files-specific.outputs.all_changed_files }},
+              deletions: ${{ steps.changed-files-specific.outputs.deleted_files }},
+              operation: "preview",
+              siteEnv: "prod",
+              branch: "${{ needs.set-state.outputs.branch_short_ref }}",
+              pathPrefix: "${{ needs.set-state.outputs.path_prefix }}"
+            });
+
+      - name: Force deploy all files to prod (Step 1 of 2)
+        if: needs.set-state.outputs.deploy_prod == 'true' && needs.set-state.outputs.deploy_All == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const script = require('./scripts/deploy.js');
+
+            await script({
+              core,
+              changes: ${{ steps.all-files.outputs.all_files }},
+              deletions: [],
+              operation: "preview",
+              siteEnv: "prod",
+              branch: "${{ needs.set-state.outputs.branch_short_ref }}",
+              pathPrefix: "${{ needs.set-state.outputs.path_prefix }}"
+            });
+
+      - name: Sleep for 60 seconds before living on prod
+        if: needs.set-state.outputs.deploy_prod == 'true'
+        run: sleep 60s
+        shell: bash
+
+      - name: Deploy only changed files to prod (Step 2 of 2)
+        if: needs.set-state.outputs.deploy_prod == 'true' && steps.changed-files-specific.outputs.any_modified == 'true' && needs.set-state.outputs.deploy_All == 'false'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const script = require('./scripts/deploy.js');
+
+            await script({
+              core,
+              changes: ${{ steps.changed-files-specific.outputs.all_changed_files }},
+              deletions: ${{ steps.changed-files-specific.outputs.deleted_files }},
+              operation: "live",
+              siteEnv: "prod",
+              branch: "${{ needs.set-state.outputs.branch_short_ref }}",
+              pathPrefix: "${{ needs.set-state.outputs.path_prefix }}"
+            });
+
+      - name: Force deploy all files to prod (Step 2 of 2)
+        if: needs.set-state.outputs.deploy_prod == 'true' && needs.set-state.outputs.deploy_All == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const script = require('./scripts/deploy.js');
+
+            await script({
+              core,
+              changes: ${{ steps.all-files.outputs.all_files }},
+              deletions: [],
+              operation: "live",
+              siteEnv: "prod",
+              branch: "${{ needs.set-state.outputs.branch_short_ref }}",
+              pathPrefix: "${{ needs.set-state.outputs.path_prefix }}"
+            });
+
+      - name: Sleep for 30 seconds before cleaning prod cache
+        if: needs.set-state.outputs.deploy_prod == 'true'
+        run: sleep 30s
+        shell: bash
+
+      - name: Clean cache on only changed files on prod
+        if: needs.set-state.outputs.deploy_prod == 'true' && steps.changed-files-specific.outputs.any_modified == 'true' && needs.set-state.outputs.deploy_All == 'false'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const script = require('./scripts/deploy.js');
+
+            await script({
+              core,
+              changes: ${{ steps.changed-files-specific.outputs.all_changed_files }},
+              deletions: ${{ steps.changed-files-specific.outputs.deleted_files }},
+              operation: "cache",
+              siteEnv: "stage",
+              branch: "${{ needs.set-state.outputs.branch_short_ref }}",
+              pathPrefix: "${{ needs.set-state.outputs.path_prefix }}"
+            });
+
+            await script({
+              core,
+              changes: ${{ steps.changed-files-specific.outputs.all_changed_files }},
+              deletions: ${{ steps.changed-files-specific.outputs.deleted_files }},
+              operation: "cache",
+              siteEnv: "prod",
+              branch: "${{ needs.set-state.outputs.branch_short_ref }}",
+              pathPrefix: "${{ needs.set-state.outputs.path_prefix }}"
+            });
+
+      - name: Clean cache on all files on prod
+        if: needs.set-state.outputs.deploy_prod == 'true' && needs.set-state.outputs.deploy_All == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const script = require('./scripts/deploy.js');
+
+            await script({
+              core,
+              changes: ${{ steps.all-files.outputs.all_files }},
+              deletions: [],
+              operation: "cache",
+              siteEnv: "stage",
+              branch: "${{ needs.set-state.outputs.branch_short_ref }}",
+              pathPrefix: "${{ needs.set-state.outputs.path_prefix }}"
+            });
+
+            await script({
+              core,
+              changes: ${{ steps.all-files.outputs.all_files }},
+              deletions: [],
+              operation: "cache",
+              siteEnv: "prod",
+              branch: "${{ needs.set-state.outputs.branch_short_ref }}",
+              pathPrefix: "${{ needs.set-state.outputs.path_prefix }}"
+            });


### PR DESCRIPTION
## Description
 Reintroduces #23 (previously reverted in #25 because the in-place rewrite broke v1 callers). Ships the changes as versioned files (*-v2.yml) alongside v1, so content repos can opt into v2 on their own schedule.

## Ticket
https://jira.corp.adobe.com/browse/DEVSITE-2292

## Related PRs
- https://github.com/AdobeDocsPrivate/adp-devsite-workflow-private/pull/1
- https://github.com/AdobeDocs/adp-devsite-utils/pull/75
- https://github.com/AdobeDocs/dev-docs-template/pull/48

## Test branches
- https://github.com/AdobeDocs/adp-devsite-workflow/tree/test-v2-workflows
- https://github.com/AdobeDocs/adp-devsite-utils/tree/v2-workflows
- https://github.com/AdobeDocs/adp-devsite-branch-protection-test
- https://github.com/AdobeDocsPrivate/adp-dev-docs-private

## Tests

**Setup (testing artifact only):** For this validation pass, the test repos `adp-devsite-branch-protection-test` and `adp-dev-docs-private` have both v1 and v2 workflows installed so v1 regression and v2 can be exercised side-by-side. A normal content repo ships only one set. Because `push: main` triggers both `deploy.yml` and `deploy-v2.yml` in parallel, disable the set you're not testing via Actions → workflow → kebab menu → **Disable workflow**:

- **Phases 1-5 (v2 testing):** disable v1 (`deploy.yml`, `stage.yml`, `build-auto-generated-files.yml`)
- **Phase 6 (v1 testing):** disable v2 (`deploy-v2.yml`, `stage-v2.yml`, `build-auto-generated-files-v2.yml`)

Once all phases pass, delete the v1 workflows from these test repos so they converge on v2.

### Phase 0 — Local dev

| # | Action | Steps | Repo Config | Expected | Screenshots |
|---|--------|-------|-------------|----------|-------------|
| T00 | `npm run dev` (public repo) | 1. Checkout `adp-devsite-branch-protection-test`<br>2. Run `npm run dev` | AdobeDocs repo (public); `buildContributors` routes to `buildContributorsV2` from `adp-devsite-utils#v2-workflows` | Dev server starts on port 3003; `contributors.json` + `adp-site-metadata.json` generated locally; no API auth errors | <img width="858" height="639" alt="Screenshot 2026-05-05 at 2 17 31 PM" src="https://github.com/user-attachments/assets/cc4c505d-82b7-46cb-9c6f-93e36d9d164a" /> |
| T00b | `npm run dev` (private repo) | 1. Checkout `adp-dev-docs-private`<br>2. Run `npm run dev` | AdobeDocsPrivate repo (private) | Dev server starts on port 3003; `contributors.json` + `adp-site-metadata.json` generated locally | <img width="858" height="633" alt="Screenshot 2026-05-05 at 2 14 13 PM" src="https://github.com/user-attachments/assets/bd1dce53-c997-4913-ac66-f8299ea4c61d" /> |

### Phase 1 — v2, no branch protection

**Repo:** `adp-devsite-branch-protection-test` (AdobeDocs, public). Both `deploy-v2.yml` and `build-auto-generated-files-v2.yml` use `secrets: inherit` — Phase 1 therefore validates the inherit pattern end-to-end.

| # | Action | Steps | Repo Config | Expected | Screenshots |
|---|--------|-------|-------------|----------|-------------|
| T01 | Push to main with markdown changes | 1. Edit a `.md` file in `src/pages/`<br>2. Commit and push to main | v2 workflows, no branch protection, app secrets set, `secrets: inherit` | • All jobs green<br>• echo-state: `Has App Secrets = true`, `Deploy to prod = true`, `Deploy to stage = false`<br>• Bot commits: `chore: auto-generate contributors` + `chore: auto-generate site metadata`<br>• Prod deploy steps ran<br>• Deploy processes ONLY the user-pushed `.md` (not the bot's `contributors.json`/`adp-site-metadata.json`) — verifies `sha: head_sha` filter on changed-files | https://github.com/AdobeDocs/adp-devsite-branch-protection-test/actions/runs/25404165681/job/74511084108 <img width="1470" height="1043" alt="Screenshot 2026-05-05 at 6 15 54 PM" src="https://github.com/user-attachments/assets/113e01b6-8921-49b3-a489-21e767d11ab2" /> <img width="1470" height="1045" alt="Screenshot 2026-05-05 at 6 16 11 PM" src="https://github.com/user-attachments/assets/90b758b4-934d-4ada-ac92-8bd34ba3a455" /> <img width="1471" height="1045" alt="Screenshot 2026-05-05 at 6 16 25 PM" src="https://github.com/user-attachments/assets/c2d993fe-437d-453f-aa0e-8c3499164cb5" /> <img width="1469" height="521" alt="Screenshot 2026-05-05 at 6 18 29 PM" src="https://github.com/user-attachments/assets/0403441c-2885-478f-8bd5-454aca74e4b8" /> <img width="2940" height="2928" alt="screencapture-github-AdobeDocs-adp-devsite-branch-protection-test-actions-runs-25404165681-job-74511227054-2026-05-05-18_17_45" src="https://github.com/user-attachments/assets/4626347f-586d-46db-9f73-c971c5ab3b89" /> |
| T02 | Verify bot commit does NOT trigger deploy re-run | 1. After T01 completes, check Actions tab for a second run triggered by the bot's `auto-generate` commits | same | No new run triggered (`if: github.actor != 'adp-devsite-app[bot]'` guard on the `deployment` job blocks bot-triggered deploys) | <img width="1469" height="552" alt="Screenshot 2026-05-05 at 6 32 01 PM" src="https://github.com/user-attachments/assets/72695365-d7e1-46ff-9341-89d838bbf18f" /> |
| T03 | `workflow_dispatch`, baseSha provided, deployAll unchecked | 1. Actions → deploy workflow → Run workflow<br>2. Enter a SHA from a few commits back in `baseSha`<br>3. Leave `deployAll` unchecked<br>4. Run | same | `Base Sha` in echo-state matches provided value; delta build runs from that SHA | https://github.com/AdobeDocs/adp-devsite-branch-protection-test/actions/runs/25411792585/job/74534981847 <img width="1471" height="847" alt="Screenshot 2026-05-05 at 6 36 00 PM" src="https://github.com/user-attachments/assets/32ed7034-b366-4bd6-92d5-117ba8dd0914" /> <img width="1469" height="1001" alt="Screenshot 2026-05-05 at 6 39 46 PM" src="https://github.com/user-attachments/assets/42e98b57-c8a1-44a4-88c2-c42d7a59219c" /> (note: `npm warn deprecated glob@10.5.0` warnings may appear in build-contributors log - known issue, [DEVSITE-2381](https://jira.corp.adobe.com/browse/DEVSITE-2381)) <img width="1470" height="1045" alt="Screenshot 2026-05-05 at 6 40 05 PM" src="https://github.com/user-attachments/assets/cbf39af8-0a4a-49ec-8ca2-b80a75d074ce" /> <img width="1470" height="1045" alt="Screenshot 2026-05-05 at 6 40 18 PM" src="https://github.com/user-attachments/assets/f41b896e-698c-4187-8bef-a7bdad023a45" /> <img width="2940" height="3288" alt="screencapture-github-AdobeDocs-adp-devsite-branch-protection-test-actions-runs-25411792585-job-74535049089-2026-05-05-18_54_03" src="https://github.com/user-attachments/assets/02a9ad7d-b71f-4454-b680-c255bca157f2" /> |
| T04 | `workflow_dispatch`, deployAll checked | 1. Actions → deploy workflow → Run workflow<br>2. Leave `baseSha` empty, check `deployAll`<br>3. Run | same | `Deploy All = true` in echo-state; full rebuild runs (`--all`); all `src/pages/` files deployed | https://github.com/AdobeDocs/adp-devsite-branch-protection-test/actions/runs/25412587753/job/74537378469 <img width="1471" height="811" alt="Screenshot 2026-05-05 at 7 05 11 PM" src="https://github.com/user-attachments/assets/9bda1ded-c50e-4cf5-ae71-22395fd4b6ec" /> <img width="1470" height="1045" alt="Screenshot 2026-05-05 at 7 09 48 PM" src="https://github.com/user-attachments/assets/0a972380-e38c-4527-ae2b-20c865cdf941" /> <img width="1470" height="1045" alt="Screenshot 2026-05-05 at 7 10 05 PM" src="https://github.com/user-attachments/assets/1328e697-3cea-4198-a07c-a7753dfae81a" /> <img width="1470" height="1044" alt="Screenshot 2026-05-05 at 7 10 15 PM" src="https://github.com/user-attachments/assets/aeb9fc84-019d-4cdd-a53c-0e40e8c65f29" /> <img width="2940" height="3008" alt="screencapture-github-AdobeDocs-adp-devsite-branch-protection-test-actions-runs-25412587753-job-74537446842-2026-05-05-19_10_53" src="https://github.com/user-attachments/assets/eb8ffe02-384b-40dd-b536-11f5422927d4" /> |
| T04b | `workflow_dispatch`, env: `stage & prod` | 1. Actions → deploy workflow → Run workflow<br>2. Select `env: stage & prod`<br>3. Enter a SHA from a few commits back in `baseSha` (leaving it empty triggers a known `changed-files` shallow-clone bug - tracked in [DEVSITE-2379](https://jira.corp.adobe.com/browse/DEVSITE-2379))<br>4. Leave `deployAll` unchecked<br>5. Run | same | • echo-state: `Deploy to stage = true`, `Deploy to prod = true` (both flags set via `contains(inputs.env, ...)`)<br>• Stage steps ran (preview + cache-bust)<br>• Prod 2-step deploy ran (preview → sleep → live)<br>• Both stage and prod environments updated in a single run | https://github.com/AdobeDocs/adp-devsite-branch-protection-test/actions/runs/25414729038/job/74543758992 <img width="1466" height="812" alt="Screenshot 2026-05-05 at 8 23 23 PM" src="https://github.com/user-attachments/assets/a2382203-97d8-4f9e-8736-e13a28decf95" /> <img width="1468" height="1044" alt="Screenshot 2026-05-05 at 8 27 28 PM" src="https://github.com/user-attachments/assets/ea9d2d2b-8916-404f-89fd-db3776b5795a" /> <img width="2938" height="2728" alt="screencapture-github-AdobeDocs-adp-devsite-branch-protection-test-actions-runs-25414729038-job-74543829270-2026-05-05-20_28_14" src="https://github.com/user-attachments/assets/a4482f3f-b96b-49f5-81dd-cd48f4750e1e" /> |


### Phase 1b — Fork PR (core DEVSITE-2292 scenario)

V2 fixes fork PR failures by removing `pull_request` from `build-auto-generated-files-v2.yml` (auto-gen now only runs at deploy time, called via `workflow_call` from the deploy workflow). The linter bot also moved to a `workflow_run` trigger so it can comment on fork PRs without needing fork-side write access. These tests verify the PR-time experience is clean for both forks and internal branches.

| # | Action | Steps | Repo Config | Expected | Screenshots |
|---|--------|-------|-------------|----------|-------------|
| T05 | Fork PR with `src/pages` changes | 1. Fork `adp-devsite-branch-protection-test`<br>2. Edit a `.md` file in `src/pages/`<br>3. Open a PR against main | v2 workflows, no branch protection, app secrets set | • `Lint` check runs<br>• `Build Auto-Generated Files` check NOT present (v2 `build-auto-generated-files-v2.yml` has no `pull_request` trigger)<br>• No secrets-related failures<br>• If lint warnings found: `Post Linter Report` bot posts a comment — confirms `workflow_run`-based posting works cross-fork | https://github.com/AdobeDocs/adp-devsite-branch-protection-test/pull/52 <img width="2938" height="3220" alt="screencapture-github-AdobeDocs-adp-devsite-branch-protection-test-pull-52-2026-05-05-21_59_00" src="https://github.com/user-attachments/assets/b9ff2235-a6af-4dda-ab70-4ff9ee458bee" /> |

### Phase 2 — Branch protection

| # | Action | Steps | Repo Config | Expected | Screenshots |
|---|--------|-------|-------------|----------|-------------|
| T06 | Merge PR (App IS bypass actor) | 1. Confirm **ADP DevSite App** is set as bypass actor in ruleset<br>2. Create a feature branch, edit a `.md` file in `src/pages/`<br>3. Open a PR against main and merge it | Branch protection enabled, **App is bypass actor** (`adp-devsite-branch-protection-test`) | Merge triggers deploy workflow; `build-auto-generated-files` succeeds (bot's app-token push allowed by App's bypass); bot commit in history; deploy completes | <img width="2938" height="4470" alt="screencapture-github-AdobeDocs-adp-devsite-branch-protection-test-settings-rules-16036267-2026-05-06-08_32_29" src="https://github.com/user-attachments/assets/cb516364-8413-4085-a62e-14b5960f6c8b" /> <img width="2938" height="5414" alt="screencapture-github-AdobeDocs-adp-devsite-branch-protection-test-settings-branch-protection-rules-76590859-2026-05-06-09_09_28" src="https://github.com/user-attachments/assets/1cd09e2b-2dfc-49d7-97c4-e34b02f70aed" /> https://github.com/AdobeDocs/adp-devsite-branch-protection-test/actions/runs/25447848572/job/74656816407 <img width="1435" height="1041" alt="Screenshot 2026-05-06 at 9 50 13 AM" src="https://github.com/user-attachments/assets/8b5daac3-f579-4ec4-b67a-e87f2b1192fc" /> <img width="1433" height="1048" alt="Screenshot 2026-05-06 at 9 50 28 AM" src="https://github.com/user-attachments/assets/d81192c0-dbd8-47fa-ad8c-5d3d95246018" /> <img width="1470" height="522" alt="Screenshot 2026-05-06 at 9 32 55 AM" src="https://github.com/user-attachments/assets/ec015dfe-6d63-4596-90e7-c1841cd90dc1" /> |
| T07 | Merge PR (App NOT bypass actor) | 1. Remove **ADP DevSite App** from bypass actors<br>2. Create a feature branch, edit a `.md` file in `src/pages/`<br>3. Open a PR against main and merge it | Branch protection enabled, **App is NOT bypass actor** | • `build-contributors` fails on git push (push rejected — App lacks bypass)<br>• `build-site-metadata` still runs (not skipped — `if: always()`) and also fails on git push — confirms `needs: build-contributors` + `if: always()` chain<br>• `deploy` still runs (`if: always()`) and deploys the user's merge commit (no auto-gen file updates in branch) | <img width="2868" height="4764" alt="screencapture-github-AdobeDocs-adp-devsite-branch-protection-test-settings-branch-protection-rules-76590859-2026-05-06-09_39_06" src="https://github.com/user-attachments/assets/2ead2cf3-e2d9-47ff-abf9-38d83c409c93" /> <img width="2868" height="4574" alt="screencapture-github-AdobeDocs-adp-devsite-branch-protection-test-settings-rules-16036267-2026-05-06-09_40_07" src="https://github.com/user-attachments/assets/ffc62e33-1056-4634-ac34-c8ab3d48bd00" /> https://github.com/AdobeDocs/adp-devsite-branch-protection-test/actions/runs/25448780351/job/74660163050 <img width="1434" height="1045" alt="Screenshot 2026-05-06 at 9 53 50 AM" src="https://github.com/user-attachments/assets/5f646874-994e-437a-8066-765327e4d28a" /> <img width="1434" height="1044" alt="Screenshot 2026-05-06 at 9 54 05 AM" src="https://github.com/user-attachments/assets/362da4ed-945b-4519-905a-873f626f6d5b" /> <img width="1434" height="386" alt="Screenshot 2026-05-06 at 9 55 50 AM" src="https://github.com/user-attachments/assets/832cbc21-b771-4ed5-b497-c88da4d08753" /> |

### Phase 3 — No app secrets

**Setup:** Disable branch protection if it was left on from Phase 2 — Phase 3 reuses Phase 1's setup (no protection) so a direct push to main can trigger the workflow.

| # | Action | Steps | Repo Config | Expected | Screenshots |
|---|--------|-------|-------------|----------|-------------|
| T08 | Push to main | 1. Temporarily remove or unset `ADP_DEVSITE_APP_ID` repo secret<br>2. Push a markdown change to main | v2 workflows, `ADP_DEVSITE_APP_ID` not set | `Has App Secrets = false` in echo-state; `build-auto-generated-files` skipped; deploy completes successfully | <img width="1446" height="853" alt="Screenshot 2026-05-06 at 11 53 22 AM" src="https://github.com/user-attachments/assets/5fc5e6c8-70a2-4464-bdd7-cd6d38215195" /> https://github.com/AdobeDocs/adp-devsite-branch-protection-test/actions/runs/25455183726/job/74682627646 <img width="1448" height="875" alt="Screenshot 2026-05-06 at 12 05 24 PM" src="https://github.com/user-attachments/assets/b7298a5d-607e-4c3c-a3f3-36032e1605dc" /> <img width="1446" height="1044" alt="Screenshot 2026-05-06 at 12 07 44 PM" src="https://github.com/user-attachments/assets/c2e04e8c-04ca-49e0-aac8-2ead7664fc27" /> <img width="1447" height="802" alt="Screenshot 2026-05-06 at 12 06 46 PM" src="https://github.com/user-attachments/assets/9c35cb32-82db-4ec8-ba70-abb1488512bc" /> |

### Phase 4 — AdobeDocsPrivate cross-org

`adp-dev-docs-private` routes through `AdobeDocsPrivate/adp-devsite-workflow-private/.github/workflows/deploy-v2.yml@v2-workflows` — a parallel implementation that **always full-rebuilds, deploys to Azure (not AEM), explicitly copies `static/`, and doesn't auto-gen on push**. Build-auto-gen uses **explicit secret passing** (free-plan AdobeDocsPrivate constraint); deploy uses `secrets: inherit`.


| # | Action | Steps | Repo Config | Expected | Screenshots |
|---|--------|-------|-------------|----------|-------------|
| T09 | `workflow_dispatch` (env=prod) | 1. Actions → deploy workflow → Run workflow on `test-v2-workflows` branch<br>2. Leave `env` as default (`prod`) | AdobeDocsPrivate repo (`adp-dev-docs-private`), app secrets set as repo-level secrets | • Jobs run: `matrix_prep` → `set-state` → `echo-state` → `pre-build` → `build`<br>• echo-state: `Deploy to prod = true`, `Deploy to stg = false`, `Repository org = AdobeDocsPrivate`, `Path prefix` populated from `config.md`<br>• `build` job: full site rebuilt, static assets copied, Azure deploy completed against prod connection string, Fastly cache purged using `AIO_FASTLY_PROD_URL` | https://github.com/AdobeDocsPrivate/adp-dev-docs-private/actions/runs/25462819921/job/74709206897 <img width="1533" height="1043" alt="Screenshot 2026-05-06 at 2 49 43 PM" src="https://github.com/user-attachments/assets/7fbfb910-2071-4fa4-83df-da646da7361d" /> |
| T09b | `workflow_dispatch` via `stage-v2.yml` | 1. Actions → Staging workflow → Run workflow on `test-v2-workflows` branch | same as T09 | • echo-state: `Deploy to stg = true`, `Deploy to prod = false`<br>• `build` job runs full rebuild<br>• "Select Connection String" step picks `AIO_AZURE_DEV_PRIVATE_CONNECTION_STRING` (stage)<br>• Azure deploy targets stage (dev) Blob Storage<br>• Fastly purge uses `AIO_FASTLY_DEV_URL` | https://github.com/AdobeDocsPrivate/adp-dev-docs-private/actions/runs/25463110394/job/74710678289 <img width="1536" height="1045" alt="Screenshot 2026-05-06 at 3 03 15 PM" src="https://github.com/user-attachments/assets/e6605113-0205-4e70-bedb-4b69b24c237b" /> |
| T09c | Push `static/` file to main | 1. Edit a file under `static/` in `adp-dev-docs-private` (e.g. `static/foo.json`)<br>2. Commit and push to main | same as T09 | • `build` job runs full rebuild (private workflow has no changed-files filter)<br>• "Copy spec, data, and static media files" step copies `static/foo.json` into `_site/{pathPrefix}/static/foo.json` (preserves `static/` prefix)<br>• Deployed to Azure at `{pathPrefix}/static/foo.json`<br>• File accessible via runtime connector at `developer-stage.adobe.com/{pathPrefix}/static/foo.json` (private repos serve static via runtime connector; public repos fetch via raw GitHub instead) | https://github.com/AdobeDocsPrivate/adp-dev-docs-private/actions/runs/25463910593/job/74712749260 <img width="1537" height="1045" alt="Screenshot 2026-05-06 at 3 38 41 PM" src="https://github.com/user-attachments/assets/75a6483e-da68-479c-8f31-6a969813850d" /> <img width="1538" height="1048" alt="Screenshot 2026-05-06 at 3 38 14 PM" src="https://github.com/user-attachments/assets/94ced300-e6bd-4253-a7f9-dcada06cac13" /> |

### Phase 5 — Staging (stage-v2.yml)

| # | Action | Steps | Repo Config | Expected | Screenshots |
|---|--------|-------|-------------|----------|-------------|
| T10 | `workflow_dispatch` via `stage-v2.yml`, no baseSha | 1. Actions → Staging workflow → Run workflow from main branch of `adp-devsite-branch-protection-test` (caller calls shared workflow at `@test-v2-workflows`)<br>2. Leave `baseSha` empty, leave `deployAll` unchecked<br>3. Run | v2 workflows, app secrets set | `Deploy to stage = true`, `Deploy to prod = false` in echo-state; `Base Sha` from last successful `stage-v2.yml` run (independent of deploy baseline); auto-gen runs; stage deploy completes | https://github.com/AdobeDocs/adp-devsite-branch-protection-test/actions/runs/25463240032/job/74710433434 <img width="1534" height="1042" alt="Screenshot 2026-05-06 at 3 42 23 PM" src="https://github.com/user-attachments/assets/e5970dd8-277f-4ce5-9ba7-632dc8c894ad" /> |

### Phase 6 — v1 workflows       

Regression coverage — verifies that v2 changes to `adp-devsite-utils` (new `buildContributorsV2` function) and shared workflow restructuring don't break v1 callers still on the unchanged code paths.

| # | Action | Steps | Repo Config | Expected | Screenshots |
|---|--------|-------|-------------|----------|-------------|
| T11 | `npm run dev` (old) | 1. Checkout any v1 content repo on main<br>2. Run `npm run dev` | Any v1 repo on main | Dev server starts normally | https://github.com/AdobeDocs/adp-devsite-branch-protection-test/actions/runs/25463240032/job/74710433434 <img width="829" height="707" alt="Screenshot 2026-05-06 at 3 27 37 PM" src="https://github.com/user-attachments/assets/4ce4bd2d-119e-4fb5-b392-9a8a3b33d585" /> |
