### PR TITLE
fix: look under _site/index.html (not ${SITE_PATH}/index.html) and loosen up patter for div class

### DIFF
--- a/.github/workflows/private-deploy.yml
+++ b/.github/workflows/private-deploy.yml
@@ -404,13 +404,43 @@ jobs:
       - name: Fix superhero block images
         run: |
           cd _site
-          
+          echo "::group::Fix superhero block images (diagnostics)"
+          echo "PWD=$(pwd)"
+          echo "SITE_PATH=${SITE_PATH}"
+          PRIMARY="${SITE_PATH}/index.html"
+          ROOT_INDEX="index.html"
+          echo "Primary target (workflow): ${PRIMARY}"
+          echo "Root crawl target (often actual home): ${ROOT_INDEX}"
+          if [ -f "${PRIMARY}" ]; then
+            echo "Primary exists: yes ($(wc -c < "${PRIMARY}" | tr -d ' ') bytes)"
+          else
+            echo "Primary exists: no"
+          fi
+          if [ -f "${ROOT_INDEX}" ]; then
+            echo "Root index.html exists: yes ($(wc -c < "${ROOT_INDEX}" | tr -d ' ') bytes)"
+          else
+            echo "Root index.html exists: no"
+          fi
+          echo "Superhero-related snippets in primary (if present):"
+          grep -n 'class="superhero"' "${PRIMARY}" 2>/dev/null | head -5 || echo "  (none or file missing)"
+          echo "Superhero-related snippets in root index (if present):"
+          grep -n 'class="superhero"' "${ROOT_INDEX}" 2>/dev/null | head -5 || echo "  (none or file missing)"
+          echo "::endgroup::"
+
           # The superhero.js expects <picture><img></picture> but we have plain <img>
           # Wrap superhero images in <picture> elements so the background works
           if [ -f "${SITE_PATH}/index.html" ]; then
-            # Find <img> tags in superhero blocks and wrap them in <picture>
+            echo "::group::Perl wrap on ${SITE_PATH}/index.html"
+            BEFORE=$(grep -o '<picture><img' "${SITE_PATH}/index.html" 2>/dev/null | wc -l | tr -d ' ')
+            echo "Count <picture><img before: ${BEFORE}"
             perl -i -0pe 's|(<div class="superhero">.*?<div>\s*)<img ([^>]+)>(.*?</div>\s*</div>)|$1<picture><img $2></picture>$3|gs' "${SITE_PATH}/index.html"
-            echo "✓ Superhero images wrapped in <picture>"
+            AFTER=$(grep -o '<picture><img' "${SITE_PATH}/index.html" 2>/dev/null | wc -l | tr -d ' ')
+            echo "Count <picture><img after: ${AFTER}"
+            echo "✓ Superhero images wrapped in <picture> (${SITE_PATH}/index.html)"
+            echo "::endgroup::"
+          else
+            echo "○ Skipped superhero HTML fix: file not found at ${SITE_PATH}/index.html"
+            echo "  (If the home page was crawled to index.html at _site root, use that path in this step.)"
           fi
 
       - name: Add security headers

--- a/.github/workflows/private-deploy.yml
+++ b/.github/workflows/private-deploy.yml
@@ -404,50 +404,19 @@ jobs:
       - name: Fix superhero block images
         run: |
           cd _site
-          echo "::group::Fix superhero block images (diagnostics)"
-          echo "PWD=$(pwd)"
-          echo "SITE_PATH=${SITE_PATH}"
-          PRIMARY="${SITE_PATH}/index.html"
-          ROOT_INDEX="index.html"
-          echo "Primary target (workflow): ${PRIMARY}"
-          echo "Root crawl target (often actual home): ${ROOT_INDEX}"
-          if [ -f "${PRIMARY}" ]; then
-            echo "Primary exists: yes ($(wc -c < "${PRIMARY}" | tr -d ' ') bytes)"
-          else
-            echo "Primary exists: no"
-          fi
-          if [ -f "${ROOT_INDEX}" ]; then
-            echo "Root index.html exists: yes ($(wc -c < "${ROOT_INDEX}" | tr -d ' ') bytes)"
-          else
-            echo "Root index.html exists: no"
-          fi
-          echo "Superhero-related snippets in primary (if present):"
-          grep -n 'class="superhero"' "${PRIMARY}" 2>/dev/null | head -5 || echo "  (none or file missing)"
-          echo "Superhero-related snippets in root index (if present):"
-          grep -n 'class="superhero"' "${ROOT_INDEX}" 2>/dev/null | head -5 || echo "  (none or file missing)"
-          echo "::endgroup::"
-
-          # The superhero.js expects <picture><img></picture> but we have plain <img>
-          # Crawl writes the home page to index.html at _site root, not ${SITE_PATH}/index.html
-          # Wrap superhero images in <picture> on every static file that contains a superhero block
-          SH_PATTERN='class="superhero"'
-          SH_FILES=$(grep -rl "$SH_PATTERN" . 2>/dev/null || true)
+          # superhero.js expects <picture><img>; crawl may emit plain <img>. Home page is often
+          # _site/index.html (not ${SITE_PATH}/index.html). Fix every file under _site that contains the block.
+          SH_FILES=$(grep -rl 'class="superhero"' . 2>/dev/null || true)
           if [ -z "$SH_FILES" ]; then
-            echo "○ No files under _site contain superhero — nothing to fix"
+            echo "○ No superhero blocks in _site — skip"
           else
-            echo "Files to process (contain superhero):"
-            echo "$SH_FILES" | sed 's/^/  - /'
+            echo "Superhero HTML fix (wrap <img> in <picture>):"
+            echo "$SH_FILES" | sed 's/^/  /'
             echo "$SH_FILES" | while IFS= read -r f; do
               [ -z "$f" ] && continue
               [ -f "$f" ] || continue
-              echo "::group::Perl wrap on $f"
-              BEFORE=$(grep -o '<picture><img' "$f" 2>/dev/null | wc -l | tr -d ' ')
-              echo "Count <picture><img before: ${BEFORE}"
               perl -i -0pe 's|(<div class="superhero">.*?<div>\s*)<img ([^>]+)>(.*?</div>\s*</div>)|$1<picture><img $2></picture>$3|gs' "$f"
-              AFTER=$(grep -o '<picture><img' "$f" 2>/dev/null | wc -l | tr -d ' ')
-              echo "Count <picture><img after: ${AFTER}"
-              echo "✓ Processed: $f"
-              echo "::endgroup::"
+              echo "  ✓ $f"
             done
           fi
 

--- a/.github/workflows/private-deploy.yml
+++ b/.github/workflows/private-deploy.yml
@@ -406,7 +406,9 @@ jobs:
           cd _site
           # superhero.js expects <picture><img>; crawl may emit plain <img>. Home page is often
           # _site/index.html (not ${SITE_PATH}/index.html). Fix every file under _site that contains the block.
-          SH_FILES=$(grep -rl 'class="superhero"' . 2>/dev/null || true)
+          # Match any div whose class list includes "superhero" (default, half-width, etc.); first bare <img>
+          # inside that open tag must not already follow <picture> (avoid double-wrap on re-run).
+          SH_FILES=$(grep -rl 'class="[^"]*superhero' . 2>/dev/null || true)
           if [ -z "$SH_FILES" ]; then
             echo "○ No superhero blocks in _site — skip"
           else
@@ -415,7 +417,7 @@ jobs:
             echo "$SH_FILES" | while IFS= read -r f; do
               [ -z "$f" ] && continue
               [ -f "$f" ] || continue
-              perl -i -0pe 's|(<div class="superhero">.*?<div>\s*)<img ([^>]+)>(.*?</div>\s*</div>)|$1<picture><img $2></picture>$3|gs' "$f"
+              perl -i -0pe 's|(<div\s+class="[^"]*\bsuperhero\b[^"]*"[^>]*>[\s\S]*?)(?<!<picture>)<img([^>]*)>|$1<picture><img$2></picture>|gs' "$f"
               echo "  ✓ $f"
             done
           fi

--- a/.github/workflows/private-deploy.yml
+++ b/.github/workflows/private-deploy.yml
@@ -404,13 +404,12 @@ jobs:
       - name: Fix superhero block images
         run: |
           cd _site
-          # superhero.js expects <picture><img>; crawl may emit plain <img>. Home page is often
-          # _site/index.html (not ${SITE_PATH}/index.html). Fix every file under _site that contains the block.
+          # superhero.js expects <picture><img>; Fix every file under _site that contains the block.
           # Match any div whose class list includes "superhero" (default, half-width, etc.); first bare <img>
-          # inside that open tag must not already follow <picture> (avoid double-wrap on re-run).
+          # inside that open tag must not already follow <picture> (avoids double-wrapping)
           SH_FILES=$(grep -rl 'class="[^"]*superhero' . 2>/dev/null || true)
           if [ -z "$SH_FILES" ]; then
-            echo "○ No superhero blocks in _site — skip"
+            echo "No superhero blocks in _site — skip"
           else
             echo "Superhero HTML fix (wrap <img> in <picture>):"
             echo "$SH_FILES" | sed 's/^/  /'

--- a/.github/workflows/private-deploy.yml
+++ b/.github/workflows/private-deploy.yml
@@ -428,19 +428,27 @@ jobs:
           echo "::endgroup::"
 
           # The superhero.js expects <picture><img></picture> but we have plain <img>
-          # Wrap superhero images in <picture> elements so the background works
-          if [ -f "${SITE_PATH}/index.html" ]; then
-            echo "::group::Perl wrap on ${SITE_PATH}/index.html"
-            BEFORE=$(grep -o '<picture><img' "${SITE_PATH}/index.html" 2>/dev/null | wc -l | tr -d ' ')
-            echo "Count <picture><img before: ${BEFORE}"
-            perl -i -0pe 's|(<div class="superhero">.*?<div>\s*)<img ([^>]+)>(.*?</div>\s*</div>)|$1<picture><img $2></picture>$3|gs' "${SITE_PATH}/index.html"
-            AFTER=$(grep -o '<picture><img' "${SITE_PATH}/index.html" 2>/dev/null | wc -l | tr -d ' ')
-            echo "Count <picture><img after: ${AFTER}"
-            echo "✓ Superhero images wrapped in <picture> (${SITE_PATH}/index.html)"
-            echo "::endgroup::"
+          # Crawl writes the home page to index.html at _site root, not ${SITE_PATH}/index.html
+          # Wrap superhero images in <picture> on every static file that contains a superhero block
+          SH_PATTERN='class="superhero"'
+          SH_FILES=$(grep -rl "$SH_PATTERN" . 2>/dev/null || true)
+          if [ -z "$SH_FILES" ]; then
+            echo "○ No files under _site contain superhero — nothing to fix"
           else
-            echo "○ Skipped superhero HTML fix: file not found at ${SITE_PATH}/index.html"
-            echo "  (If the home page was crawled to index.html at _site root, use that path in this step.)"
+            echo "Files to process (contain superhero):"
+            echo "$SH_FILES" | sed 's/^/  - /'
+            echo "$SH_FILES" | while IFS= read -r f; do
+              [ -z "$f" ] && continue
+              [ -f "$f" ] || continue
+              echo "::group::Perl wrap on $f"
+              BEFORE=$(grep -o '<picture><img' "$f" 2>/dev/null | wc -l | tr -d ' ')
+              echo "Count <picture><img before: ${BEFORE}"
+              perl -i -0pe 's|(<div class="superhero">.*?<div>\s*)<img ([^>]+)>(.*?</div>\s*</div>)|$1<picture><img $2></picture>$3|gs' "$f"
+              AFTER=$(grep -o '<picture><img' "$f" 2>/dev/null | wc -l | tr -d ' ')
+              echo "Count <picture><img after: ${AFTER}"
+              echo "✓ Processed: $f"
+              echo "::endgroup::"
+            done
           fi
 
       - name: Add security headers


### PR DESCRIPTION
Before this fix was looking at the wrong file paths and the pattern looking for divs with class name = superhero was too strict so now it's looking all the files and fetching every superhero div:
- https://developer-stage.adobe.com/private-eds/
- https://developer-stage.adobe.com/private-eds/support/