### PR TITLE
chore: upgrade actions/github-script from v7 to v8 for Node.js 24 compatibility

### DIFF
--- a/.github/workflows/ai-deploy-metadata.yml
+++ b/.github/workflows/ai-deploy-metadata.yml
@@ -99,7 +99,7 @@ jobs:
           npm install
           
       - name: Fetch all pages content
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const script = require('./scripts/fetch-pages-scripts.js');
@@ -113,7 +113,7 @@ jobs:
             });
           
       - name: Run AI metadata generation script
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const script = require('./scripts/ai-scripts.js');
@@ -126,7 +126,7 @@ jobs:
             });
           
       - name: Push Commit and Create PR
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const script = require('./scripts/create-pr-scripts.js');

--- a/.github/workflows/ai-metadata-changed-files.yml
+++ b/.github/workflows/ai-metadata-changed-files.yml
@@ -124,7 +124,7 @@ jobs:
           base_sha: ${{ needs.set-state.outputs.base_Sha }}
 
       - name: Fetch content for changed files
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const script = require('./scripts/process-changed-files-scripts.js');
@@ -143,7 +143,7 @@ jobs:
             });
 
       - name: Run AI metadata generation script
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const script = require('./scripts/ai-scripts.js');
@@ -156,7 +156,7 @@ jobs:
             });
 
       - name: Create PR with generated metadata
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const script = require('./scripts/create-pr-scripts.js');

--- a/.github/workflows/ai-pr-request-metadata.yml
+++ b/.github/workflows/ai-pr-request-metadata.yml
@@ -82,7 +82,7 @@ jobs:
           npm install
           
       - name: Run PR script
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const script = require('./scripts/pr-scripts.js');
@@ -96,7 +96,7 @@ jobs:
             });
           
       - name: Run AI metadata generation script
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const script = require('./scripts/ai-scripts.js');
@@ -109,7 +109,7 @@ jobs:
             });
           
       - name: Run review PR script
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const script = require('./scripts/review-scripts.js');

--- a/.github/workflows/deploy-v2.yml
+++ b/.github/workflows/deploy-v2.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Get last successful workflow_dispatch run
         id: last_successful_workflow_dispatch_run
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const { owner, repo } = context.repo;
@@ -71,7 +71,7 @@ jobs:
           ref: main
 
       - name: Get path prefix
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         id: get_path_prefix
         with:
           script: |
@@ -86,7 +86,7 @@ jobs:
 
       - name: Validate branch name
         if: contains(steps.get_branch.outputs.branch, '/')
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             core.setFailed("Branch name '${{ steps.get_branch.outputs.branch }}' contains a slash (/), which is not supported by EDS. Please rename your branch to remove the slash and try again.");
@@ -155,7 +155,7 @@ jobs:
       - name: Get all files from src/pages folder
         if: needs.set-state.outputs.deploy_all == 'true'
         id: all-files
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const patterns = ['src/pages/**/*.*'];
@@ -175,7 +175,7 @@ jobs:
 
       - name: Deploy only changed files to stage
         if: needs.set-state.outputs.deploy_stage == 'true' && steps.changed-files-specific.outputs.any_modified == 'true' && needs.set-state.outputs.deploy_all == 'false'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const script = require('./scripts/deploy.js');
@@ -192,7 +192,7 @@ jobs:
 
       - name: Force deploy all files to stage
         if: needs.set-state.outputs.deploy_stage == 'true' && needs.set-state.outputs.deploy_all == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const script = require('./scripts/deploy.js');
@@ -214,7 +214,7 @@ jobs:
 
       - name: Clean cache on only changed files on stage
         if: needs.set-state.outputs.deploy_stage == 'true' && steps.changed-files-specific.outputs.any_modified == 'true' && needs.set-state.outputs.deploy_all == 'false'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const script = require('./scripts/deploy.js');
@@ -231,7 +231,7 @@ jobs:
 
       - name: Clean cache on all files on stage
         if: needs.set-state.outputs.deploy_stage == 'true' && needs.set-state.outputs.deploy_all == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const script = require('./scripts/deploy.js');
@@ -248,7 +248,7 @@ jobs:
 
       - name: Deploy only changed files to prod (Step 1 of 2)
         if: needs.set-state.outputs.deploy_prod == 'true' && steps.changed-files-specific.outputs.any_modified == 'true' && needs.set-state.outputs.deploy_all == 'false'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const script = require('./scripts/deploy.js');
@@ -265,7 +265,7 @@ jobs:
 
       - name: Force deploy all files to prod (Step 1 of 2)
         if: needs.set-state.outputs.deploy_prod == 'true' && needs.set-state.outputs.deploy_all == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const script = require('./scripts/deploy.js');
@@ -287,7 +287,7 @@ jobs:
 
       - name: Deploy only changed files to prod (Step 2 of 2)
         if: needs.set-state.outputs.deploy_prod == 'true' && steps.changed-files-specific.outputs.any_modified == 'true' && needs.set-state.outputs.deploy_all == 'false'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const script = require('./scripts/deploy.js');
@@ -304,7 +304,7 @@ jobs:
 
       - name: Force deploy all files to prod (Step 2 of 2)
         if: needs.set-state.outputs.deploy_prod == 'true' && needs.set-state.outputs.deploy_all == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const script = require('./scripts/deploy.js');
@@ -326,7 +326,7 @@ jobs:
 
       - name: Clean cache on only changed files on prod
         if: needs.set-state.outputs.deploy_prod == 'true' && steps.changed-files-specific.outputs.any_modified == 'true' && needs.set-state.outputs.deploy_all == 'false'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const script = require('./scripts/deploy.js');
@@ -353,7 +353,7 @@ jobs:
 
       - name: Clean cache on all files on prod
         if: needs.set-state.outputs.deploy_prod == 'true' && needs.set-state.outputs.deploy_all == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const script = require('./scripts/deploy.js');

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,7 +48,7 @@ jobs:
           ref: main
 
       - name: Get path prefix
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         id: get_path_prefix
         with:
           script: |
@@ -63,7 +63,7 @@ jobs:
 
       - name: Validate branch name
         if: contains(steps.get_branch.outputs.branch, '/')
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             core.setFailed("Branch name '${{ steps.get_branch.outputs.branch }}' contains a slash (/), which is not supported by EDS. Please rename your branch to remove the slash and try again.");
@@ -126,7 +126,7 @@ jobs:
 
       - name: Get last successful workflow_dispatch run
         id: last_successful_workflow_dispatch_run
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const { owner, repo } = context.repo;
@@ -175,7 +175,7 @@ jobs:
       - name: Get all files from src/pages folder
         if: needs.set-state.outputs.deploy_All == 'true'
         id: all-files
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const patterns = ['src/pages/**/*.*'];
@@ -195,7 +195,7 @@ jobs:
 
       - name: Deploy only changed files to stage
         if: needs.set-state.outputs.deploy_stage == 'true' && steps.changed-files-specific.outputs.any_modified == 'true' && needs.set-state.outputs.deploy_All == 'false'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const script = require('./scripts/deploy.js');
@@ -212,7 +212,7 @@ jobs:
 
       - name: Force deploy all files to stage
         if: needs.set-state.outputs.deploy_stage == 'true' && needs.set-state.outputs.deploy_All == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const script = require('./scripts/deploy.js');
@@ -234,7 +234,7 @@ jobs:
 
       - name: Clean cache on only changed files on stage
         if: needs.set-state.outputs.deploy_stage == 'true' && steps.changed-files-specific.outputs.any_modified == 'true' && needs.set-state.outputs.deploy_All == 'false'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const script = require('./scripts/deploy.js');
@@ -251,7 +251,7 @@ jobs:
 
       - name: Clean cache on all files on stage
         if: needs.set-state.outputs.deploy_stage == 'true' && needs.set-state.outputs.deploy_All == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const script = require('./scripts/deploy.js');
@@ -268,7 +268,7 @@ jobs:
 
       - name: Deploy only changed files to prod (Step 1 of 2)
         if: needs.set-state.outputs.deploy_prod == 'true' && steps.changed-files-specific.outputs.any_modified == 'true' && needs.set-state.outputs.deploy_All == 'false'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const script = require('./scripts/deploy.js');
@@ -285,7 +285,7 @@ jobs:
 
       - name: Force deploy all files to prod (Step 1 of 2)
         if: needs.set-state.outputs.deploy_prod == 'true' && needs.set-state.outputs.deploy_All == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const script = require('./scripts/deploy.js');
@@ -307,7 +307,7 @@ jobs:
 
       - name: Deploy only changed files to prod (Step 2 of 2)
         if: needs.set-state.outputs.deploy_prod == 'true' && steps.changed-files-specific.outputs.any_modified == 'true' && needs.set-state.outputs.deploy_All == 'false'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const script = require('./scripts/deploy.js');
@@ -324,7 +324,7 @@ jobs:
 
       - name: Force deploy all files to prod (Step 2 of 2)
         if: needs.set-state.outputs.deploy_prod == 'true' && needs.set-state.outputs.deploy_All == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const script = require('./scripts/deploy.js');
@@ -346,7 +346,7 @@ jobs:
 
       - name: Clean cache on only changed files on prod
         if: needs.set-state.outputs.deploy_prod == 'true' && steps.changed-files-specific.outputs.any_modified == 'true' && needs.set-state.outputs.deploy_All == 'false'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const script = require('./scripts/deploy.js');
@@ -373,7 +373,7 @@ jobs:
 
       - name: Clean cache on all files on prod
         if: needs.set-state.outputs.deploy_prod == 'true' && needs.set-state.outputs.deploy_All == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const script = require('./scripts/deploy.js');

--- a/.github/workflows/gatsby-deploy.yml
+++ b/.github/workflows/gatsby-deploy.yml
@@ -111,7 +111,7 @@ jobs:
           ref: main
 
       - name: Get path prefix
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         id: get_path_prefix
         with:
           script: |

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Comment on PR
         if: steps.lint-results.outputs.has_warnings == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const prNumber = ${{ steps.lint-results.outputs.pr_number }};

--- a/.github/workflows/upload-playground.yml
+++ b/.github/workflows/upload-playground.yml
@@ -91,7 +91,7 @@ jobs:
 
       - name: Upload changed code blocks to FFC
         if: steps.files.outputs.list != ''
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           IMS_BASE_URL: ${{ secrets.IMS_BASE_URL }}
           FFC_BASE_URL: ${{ secrets.FFC_BASE_URL }}


### PR DESCRIPTION
## Description

- Upgrades actions/github-script from v7 to v8 across all workflow files
- v7 bundles Node.js 20, which GitHub Actions is [deprecating on June 2nd, 2026](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) — actions running on it will be forced to Node.js 24 and may break
- v8 bundles Node.js 24 and resolves the deprecation warning visible in [this example job output](https://github.com/AdobeDocs/adp-devsite-branch-protection-test/actions/runs/25699877195/job/75457494853)
- Note: [v9 is now the latest](https://github.com/actions/github-script/releases/tag/v9.0.0) but has ESM breaking changes — v8 is the safe incremental upgrade

## Before
https://github.com/AdobeDocs/adp-devsite-branch-protection-test/actions/runs/25699877195/job/75457494853
<img width="1519" height="1036" alt="Screenshot 2026-05-11 at 3 19 55 PM" src="https://github.com/user-attachments/assets/6b7b443d-55d9-4405-afc2-dba6ab1acd9e" />

## After
<img width="1521" height="1037" alt="Screenshot 2026-05-11 at 3 25 04 PM" src="https://github.com/user-attachments/assets/f04c5325-a4ec-4404-8cc6-0a549b05fe75" />

https://github.com/AdobeDocs/adp-devsite-branch-protection-test/actions/runs/25700808824/job/75460445779 

<img width="1517" height="1037" alt="Screenshot 2026-05-11 at 3 27 53 PM" src="https://github.com/user-attachments/assets/135766e0-243a-4bc5-ae37-03aee90d952b" />
