### PR TITLE
chore: upgrade actions/github-script from v7 to v8 for Node.js 24 compatibility

### DIFF
--- a/.github/workflows/private-deploy.yml
+++ b/.github/workflows/private-deploy.yml
@@ -141,7 +141,7 @@ jobs:
     steps:
       - name: Select Connection String
         id: select_connection_string
-        uses: actions/github-script@v6
+        uses: actions/github-script@v8
         env:
           AIO_AZURE_DEV_PRIVATE_CONNECTION_STRING: ${{ secrets.AIO_AZURE_DEV_PRIVATE_CONNECTION_STRING }}
           AIO_AZURE_PROD_PRIVATE_CONNECTION_STRING: ${{ secrets.AIO_AZURE_PROD_PRIVATE_CONNECTION_STRING }}


### PR DESCRIPTION
Upgrades actions/github-script from v6 to v8, matching https://github.com/AdobeDocs/adp-devsite-workflow/pull/34.

Note: Node.js 20 warnings in private deploys will persist until the external actions are also updated — tracked in [DEVSITE-2407](https://jira.corp.adobe.com/browse/DEVSITE-2407).