### PR TITLE
fix: fetch full history to resolve ref-not-found on push

### DIFF
--- a/.github/workflows/deploy-v2.yml
+++ b/.github/workflows/deploy-v2.yml
@@ -126,6 +126,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Checkout Scripts Repo
         uses: actions/checkout@v6

--- a/.github/workflows/deploy-v2.yml
+++ b/.github/workflows/deploy-v2.yml
@@ -26,7 +26,8 @@ jobs:
           script: |
             const { owner, repo } = context.repo;
             const branch = context.ref.replace('refs/heads/', '');
-            const workflowId = '${{ contains(inputs.env, 'prod') && 'deploy-v2.yml' || 'stage-v2.yml' }}';
+            // Consumer repos using v2 still name their caller files deploy.yml / stage.yml — they just point to deploy-v2.yml
+            const workflowId = '${{ contains(inputs.env, 'prod') && 'deploy.yml' || 'stage.yml' }}';
             try {
               const workflowRuns = await github.rest.actions.listWorkflowRuns({
                 owner,

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -116,6 +116,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Checkout Scripts Repo
         uses: actions/checkout@v6


### PR DESCRIPTION
## Description
**Issue:** `tj-actions/changed-files` fails on push events because the shallow clone (depth 1) forces it to fetch missing history via the GitHub refs API, which returns 404.

**Fix:** Add `fetch-depth: 0` to the deploy job checkout so full history is available locally.

**Also fixes**: `get-base-sha` was looking up `deploy-v2.yml` in content repos, but callers are still named `deploy.yml` - so no previous runs were found and `base_sha` was always empty.


## Ticket
https://jira.corp.adobe.com/browse/DEVSITE-2380

| version | before | after |
| -- | -- | -- |
| 1 | https://github.com/AdobeDocs/adp-devsite-github-actions-test/actions/runs/26121474312/job/76824286362 <img width="1469" height="1044" alt="v1 before" src="https://github.com/user-attachments/assets/cae8b4a5-6d11-4ab5-9a65-7407c105306d" /> | https://github.com/AdobeDocs/adp-devsite-github-actions-test/actions/runs/26126074736/job/76840002407 <img width="1470" height="1045" alt="v1 after" src="https://github.com/user-attachments/assets/55967c07-cf4a-4be2-818b-2664592a99b3" /> |
| 2 + push only | https://github.com/AdobeDocs/adp-devsite-github-actions-test/actions/runs/26124111970/job/76834067639 <img width="1470" height="1045" alt="v2 before" src="https://github.com/user-attachments/assets/094ce84f-9c6b-4cff-8738-bb20afa7d249" /> | https://github.com/AdobeDocs/adp-devsite-github-actions-test/actions/runs/26125463755/job/76838620013 <img width="1470" height="1045" alt="v2 after" src="https://github.com/user-attachments/assets/ab2f4379-24bc-4252-96d8-95b10357178d" /> |