### PR TITLE
fix: prevent Not Found error caused by unreachable or stale base SHA

### DIFF
--- a/.github/workflows/deploy-v2.yml
+++ b/.github/workflows/deploy-v2.yml
@@ -38,12 +38,19 @@ jobs:
                 per_page: 1,
               });
               if (workflowRuns.data.workflow_runs.length > 0) {
-                core.setOutput('base_sha', workflowRuns.data.workflow_runs[0].head_sha);
+                const lastSuccessfulRun = workflowRuns.data.workflow_runs[0];
+                console.log(`Last successful deploy on branch '${branch}':`);
+                console.log(`ID: ${lastSuccessfulRun.id}`);
+                console.log(`Commit SHA: ${lastSuccessfulRun.head_sha}`);
+                console.log(`Run URL: ${lastSuccessfulRun.html_url}`);
+                core.setOutput('base_sha', lastSuccessfulRun.head_sha);
               } else {
+                console.log(`No successful deploys found on branch '${branch}' for workflow '${workflowId}'.`);
                 core.setOutput('base_sha', '');
               }
             } catch (error) {
               console.log(`Error fetching workflow runs: ${error.message}`);
+              console.log(`Workflow '${workflowId}' may not exist in this repository. Defaulting base to empty string.`);
               core.setOutput('base_sha', '');
             }
 

--- a/.github/workflows/deploy-v2.yml
+++ b/.github/workflows/deploy-v2.yml
@@ -17,10 +17,10 @@ jobs:
   get-base-sha:
     runs-on: ubuntu-latest
     outputs:
-      base_sha: ${{ steps.last_successful_workflow_dispatch_run.outputs.base_sha }}
+      base_sha: ${{ steps.last-successful-deploy.outputs.base_sha }}
     steps:
-      - name: Get last successful workflow_dispatch run
-        id: last_successful_workflow_dispatch_run
+      - name: Get last successful deploy
+        id: last-successful-deploy
         uses: actions/github-script@v8
         with:
           script: |
@@ -34,7 +34,6 @@ jobs:
                 repo,
                 workflow_id: workflowId,
                 branch: branch,
-                event: 'workflow_dispatch',
                 status: 'success',
                 per_page: 1,
               });
@@ -140,6 +139,10 @@ jobs:
       - name: Get head SHA
         id: get-head-sha
         run: echo "head_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Unshallow repository
+        if: needs.set-state.outputs.deploy_all == 'false' && needs.set-state.outputs.base_sha != ''
+        run: git fetch --unshallow 2>/dev/null || true
 
       - name: Get changed files in the src/pages folder
         if: needs.set-state.outputs.deploy_all == 'false'

--- a/.github/workflows/deploy-v2.yml
+++ b/.github/workflows/deploy-v2.yml
@@ -126,8 +126,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
 
       - name: Checkout Scripts Repo
         uses: actions/checkout@v6

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -124,8 +124,8 @@ jobs:
           path: scripts
           ref: main
 
-      - name: Get last successful workflow_dispatch run
-        id: last_successful_workflow_dispatch_run
+      - name: Get last successful deploy
+        id: last-successful-deploy
         uses: actions/github-script@v8
         with:
           script: |
@@ -139,20 +139,19 @@ jobs:
                 repo,
                 workflow_id: workflowId,
                 branch: branch,
-                event: 'workflow_dispatch',
                 status: 'success',
                 per_page: 1, // Only need the latest one
               });
 
               if (workflowRuns.data.workflow_runs.length > 0) {
                 const lastSuccessfulRun = workflowRuns.data.workflow_runs[0];
-                console.log(`Last successful workflow_dispatch run on branch '${branch}':`);
+                console.log(`Last successful deploy on branch '${branch}':`);
                 console.log(`ID: ${lastSuccessfulRun.id}`);
                 console.log(`Commit SHA: ${lastSuccessfulRun.head_sha}`);
                 console.log(`Run URL: ${lastSuccessfulRun.html_url}`);
                 core.setOutput('base', lastSuccessfulRun.head_sha);
               } else {
-                console.log(`No successful workflow_dispatch runs found on branch '${branch}' for workflow '${workflowId}'.`);
+                console.log(`No successful deploys found on branch '${branch}' for workflow '${workflowId}'.`);
                 core.setOutput('base', '');
               }
             } catch (error) {
@@ -160,6 +159,14 @@ jobs:
               console.log(`Workflow '${workflowId}' may not exist in this repository. Defaulting base to empty string.`);
               core.setOutput('base', '');
             }
+
+      - name: Resolve base SHA
+        id: resolve-base-sha
+        run: echo "sha=${{ needs.set-state.outputs.base_Sha || steps.last-successful-deploy.outputs.base }}" >> "$GITHUB_OUTPUT"
+
+      - name: Unshallow repository
+        if: needs.set-state.outputs.deploy_All == 'false' && steps.resolve-base-sha.outputs.sha != ''
+        run: git fetch --unshallow 2>/dev/null || true
 
       - name: Get changed files in the src/pages folder
         if: needs.set-state.outputs.deploy_All == 'false'
@@ -170,7 +177,7 @@ jobs:
           escape_json: false
           files: |
             src/pages/**
-          base_sha: ${{ needs.set-state.outputs.base_Sha || steps.last_successful_workflow_dispatch_run.outputs.base }}
+          base_sha: ${{ steps.resolve-base-sha.outputs.sha }}
 
       - name: Get all files from src/pages folder
         if: needs.set-state.outputs.deploy_All == 'true'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -116,8 +116,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
 
       - name: Checkout Scripts Repo
         uses: actions/checkout@v6


### PR DESCRIPTION
## Description

Fixes two issues with `tj-actions/changed-files`:

1. **Unreachable SHA** — the shallow clone (`fetch-depth: 1`) couldn't reach the base SHA, causing `changed-files` to fail with "Not Found". Fixed by unshallowing only when a base SHA needs to be reached.
2. **Stale base SHA** — the lookup filtered to `workflow_dispatch` runs only, so on a push event it used a stale base, diffing a much larger range than necessary and re-deploying unchanged files. Fixed by looking up the latest successful deploy of any trigger.

Reverts [#36](https://github.com/AdobeDocs/adp-devsite-workflow/pull/36), which masked the crash with `fetch-depth: 0` but broke incremental deploys.

## Ticket
https://jira.corp.adobe.com/browse/DEVSITE-2380

## Test

| Version | Before | After |
|---------|--------|-------|
| v1 | [run](https://github.com/AdobeDocs/adp-devsite-github-actions-test/actions/runs/26121474312/job/76824286362) <img width="1469" height="1044" alt="v1 before" src="https://github.com/user-attachments/assets/cae8b4a5-6d11-4ab5-9a65-7407c105306d" /> | [run](https://github.com/AdobeDocs/adp-devsite-github-actions-test/actions/runs/26136876670/job/76873926995) <img width="1599" height="1037" alt="v1 after" src="https://github.com/user-attachments/assets/14faa66e-0a95-4eea-9899-79013e09166f" /> |
| v2 | [run](https://github.com/AdobeDocs/adp-devsite-github-actions-test/actions/runs/26124111970/job/76834067639) <img width="1470" height="1045" alt="v2 before" src="https://github.com/user-attachments/assets/094ce84f-9c6b-4cff-8738-bb20afa7d249" /> | [run](https://github.com/AdobeDocs/adp-devsite-github-actions-test/actions/runs/26136242451/job/76871978097) <img width="1598" height="1035" alt="Screenshot 2026-05-19 at 6 56 25 PM" src="https://github.com/user-attachments/assets/a33193b9-385e-4703-9e75-eb431631001e" /> <img width="1599" height="1039" alt="Screenshot 2026-05-19 at 6 56 16 PM" src="https://github.com/user-attachments/assets/f9d1d985-1e18-44de-810f-fa19be262023" /> |

