### PR TITLE
fix: handle identical base and HEAD SHAs on workflow_dispatch

### DIFF
--- a/.github/workflows/deploy-v2.yml
+++ b/.github/workflows/deploy-v2.yml
@@ -147,12 +147,26 @@ jobs:
         id: get-head-sha
         run: echo "head_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
-      - name: Unshallow repository
+      - name: Detect identical base and HEAD SHAs
+        id: check-sha-diff
         if: needs.set-state.outputs.deploy_all == 'false' && needs.set-state.outputs.base_sha != ''
+        run: |
+          BASE="${{ needs.set-state.outputs.base_sha }}"
+          HEAD="${{ steps.get-head-sha.outputs.head_sha }}"
+          echo "Base SHA - $BASE"
+          echo "Head SHA - $HEAD"
+          if [ "$BASE" = "$HEAD" ]; then
+            echo "base_equals_head=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "base_equals_head=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Unshallow repository
+        if: needs.set-state.outputs.deploy_all == 'false' && needs.set-state.outputs.base_sha != '' && steps.check-sha-diff.outputs.base_equals_head != 'true'
         run: git fetch --unshallow 2>/dev/null || true
 
       - name: Get changed files in the src/pages folder
-        if: needs.set-state.outputs.deploy_all == 'false'
+        if: needs.set-state.outputs.deploy_all == 'false' && steps.check-sha-diff.outputs.base_equals_head != 'true'
         id: changed-files-specific
         uses: tj-actions/changed-files@v46.0.5
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -164,12 +164,26 @@ jobs:
         id: resolve-base-sha
         run: echo "sha=${{ needs.set-state.outputs.base_Sha || steps.last-successful-deploy.outputs.base }}" >> "$GITHUB_OUTPUT"
 
-      - name: Unshallow repository
+      - name: Detect identical base and HEAD SHAs
+        id: check-sha-diff
         if: needs.set-state.outputs.deploy_All == 'false' && steps.resolve-base-sha.outputs.sha != ''
+        run: |
+          BASE="${{ steps.resolve-base-sha.outputs.sha }}"
+          HEAD=$(git rev-parse HEAD)
+          echo "Base SHA - $BASE"
+          echo "Head SHA - $HEAD"
+          if [ "$BASE" = "$HEAD" ]; then
+            echo "base_equals_head=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "base_equals_head=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Unshallow repository
+        if: needs.set-state.outputs.deploy_All == 'false' && steps.resolve-base-sha.outputs.sha != '' && steps.check-sha-diff.outputs.base_equals_head != 'true'
         run: git fetch --unshallow 2>/dev/null || true
 
       - name: Get changed files in the src/pages folder
-        if: needs.set-state.outputs.deploy_All == 'false'
+        if: needs.set-state.outputs.deploy_All == 'false' && steps.check-sha-diff.outputs.base_equals_head != 'true'
         id: changed-files-specific
         uses: tj-actions/changed-files@v46.0.5
         with:


### PR DESCRIPTION
## Description

Fixes `tj-actions/changed-files` failing on `workflow_dispatch` when no new commits have been pushed since the last successful deploy.

**Root cause** — `get-last-successful-deploy` returns a SHA equal to HEAD, so `base_sha == HEAD` is passed to `changed-files`. The action handles this case differently depending on whether `sha` is also explicitly passed:

- **v1** (only `base_sha` is passed) — the action silently falls back to an earlier commit and reports unrelated files as "changed," triggering unnecessary re-deploys.
- **v2** (both `sha` and `base_sha` are passed) — the action errors with `Similar commit hashes detected`, failing the deploy.

**Fix** — added a step to detect when `base_sha == HEAD` and skip `changed-files`. Run becomes a clean no-op — correct behavior since there is nothing new to deploy.

## Ticket
https://jira.corp.adobe.com/browse/DEVSITE-2379

## Test

Before: `workflow_dispatch` with no new commits either crashes (v2) or re-deploys files from an older base (v1).
After: `workflow_dispatch` with no new commits is a no-op (changed-files skipped).

The "Detect identical base and HEAD SHAs" step logs `Base SHA - ...` and `Head SHA - ...` — compare them in the after run to confirm they're equal.

| Version | Before | After |
|---------|--------|-------|
| v1 | [run](https://github.com/AdobeDocs/adp-devsite-branch-protection-test/actions/runs/26242027847/job/77230653537) <img width="793" height="1046" alt="v1 before" src="https://github.com/user-attachments/assets/72fca40c-9e9e-4f8a-afe9-66c9d669dfb8" /> | [run](https://github.com/AdobeDocs/adp-devsite-branch-protection-test/actions/runs/26244500222/job/77239240338) <img width="824" height="1044" alt="v1 after" src="https://github.com/user-attachments/assets/9a12d7c2-54cb-4d67-88be-54db4f671c75" /> |
| v2 | [run](https://github.com/AdobeDocs/adp-devsite-branch-protection-test/actions/runs/26243787652/job/77236914386) <img width="753" height="1043" alt="v2 before" src="https://github.com/user-attachments/assets/d73ebfe2-d8c9-4934-bd03-75ad0b012bfe" /> | [run](https://github.com/AdobeDocs/adp-devsite-branch-protection-test/actions/runs/26244935256/job/77240914149) <img width="827" height="1031" alt="v2 after" src="https://github.com/user-attachments/assets/dedd3e26-e885-419d-b336-bbe2ba3d9dae" /> |












