### PR TITLE
fix: prevent shell injection from context expressions in run blocks

### DIFF
--- a/.github/workflows/ai-metadata-changed-files.yml
+++ b/.github/workflows/ai-metadata-changed-files.yml
@@ -58,12 +58,21 @@ jobs:
     needs: [set-state]
     runs-on: ubuntu-latest
     steps:
-      - run: echo "Target branch - ${{ needs.set-state.outputs.target_branch }}"
-      - run: echo "Repository org - ${{ github.event.repository.owner.login }}"
-      - run: echo "Repository name - ${{ github.event.repository.name }}"
-      - run: echo "Repository branch - ${{ needs.set-state.outputs.branch_short_ref }}"
-      - run: echo "Base Sha - ${{ needs.set-state.outputs.base_Sha }}"
-      - run: echo "Has changed files - ${{ needs.set-state.outputs.has_changed_files }}"
+      - name: Echo state
+        env:
+          TARGET_BRANCH: ${{ needs.set-state.outputs.target_branch }}
+          REPO_ORG: ${{ github.event.repository.owner.login }}
+          REPO_NAME: ${{ github.event.repository.name }}
+          BRANCH_SHORT_REF: ${{ needs.set-state.outputs.branch_short_ref }}
+          BASE_SHA: ${{ needs.set-state.outputs.base_Sha }}
+          HAS_CHANGED_FILES: ${{ needs.set-state.outputs.has_changed_files }}
+        run: |
+          echo "Target branch - $TARGET_BRANCH"
+          echo "Repository org - $REPO_ORG"
+          echo "Repository name - $REPO_NAME"
+          echo "Repository branch - $BRANCH_SHORT_REF"
+          echo "Base Sha - $BASE_SHA"
+          echo "Has changed files - $HAS_CHANGED_FILES"
 
   ai-metadata-update:
     needs: [set-state]

--- a/.github/workflows/build-contributors-v2.yml
+++ b/.github/workflows/build-contributors-v2.yml
@@ -31,16 +31,20 @@ jobs:
           private-key: ${{ secrets.ADP_DEVSITE_APP_PRIVATE_KEY }}
 
       - name: Build Contributors
-        run: npx --yes github:AdobeDocs/adp-devsite-utils buildContributorsV2 -v ${{ inputs.buildAll && '--all' || '' }}
+        run: npx --yes github:AdobeDocs/adp-devsite-utils buildContributorsV2 -v $BUILD_ALL_FLAG
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           BASE_SHA: ${{ inputs.baseSha || github.event.before }}
+          BUILD_ALL_FLAG: ${{ inputs.buildAll && '--all' || '' }}
 
       - name: Commit and push if changed
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO: ${{ github.repository }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git remote set-url origin https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/${{ github.repository }}
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${REPO}"
           git add src/pages/contributors.json
           git pull
           git diff --cached --quiet || git commit -m "chore: auto-generate contributors"

--- a/.github/workflows/build-site-metadata-v2.yml
+++ b/.github/workflows/build-site-metadata-v2.yml
@@ -25,10 +25,13 @@ jobs:
         run: npx --yes github:AdobeDocs/adp-devsite-utils buildSiteMetadata -v
 
       - name: Commit and push if changed
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO: ${{ github.repository }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git remote set-url origin https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/${{ github.repository }}
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${REPO}"
           git add src/pages/adp-site-metadata.json
           git pull
           git diff --cached --quiet || git commit -m "chore: auto-generate site metadata"

--- a/.github/workflows/deploy-v2.yml
+++ b/.github/workflows/deploy-v2.yml
@@ -102,15 +102,27 @@ jobs:
     needs: [set-state]
     runs-on: ubuntu-latest
     steps:
-      - run: echo "Deploy to stage - ${{ needs.set-state.outputs.deploy_stage }}"
-      - run: echo "Deploy to prod - ${{ needs.set-state.outputs.deploy_prod }}"
-      - run: echo "Path prefix - ${{ needs.set-state.outputs.path_prefix }}"
-      - run: echo "Repository org - ${{ github.event.repository.owner.login }}"
-      - run: echo "Repository name - ${{ github.event.repository.name }}"
-      - run: echo "Repository branch - ${{ needs.set-state.outputs.branch_short_ref }}"
-      - run: echo "Base Sha - ${{ needs.set-state.outputs.base_sha }}"
-      - run: echo "Deploy All - ${{ needs.set-state.outputs.deploy_all }}"
-      - run: echo "Has App Secrets - ${{ needs.set-state.outputs.has_app_secrets }}"
+      - name: Echo state
+        env:
+          DEPLOY_STAGE: ${{ needs.set-state.outputs.deploy_stage }}
+          DEPLOY_PROD: ${{ needs.set-state.outputs.deploy_prod }}
+          PATH_PREFIX: ${{ needs.set-state.outputs.path_prefix }}
+          REPO_ORG: ${{ github.event.repository.owner.login }}
+          REPO_NAME: ${{ github.event.repository.name }}
+          BRANCH_SHORT_REF: ${{ needs.set-state.outputs.branch_short_ref }}
+          BASE_SHA: ${{ needs.set-state.outputs.base_sha }}
+          DEPLOY_ALL: ${{ needs.set-state.outputs.deploy_all }}
+          HAS_APP_SECRETS: ${{ needs.set-state.outputs.has_app_secrets }}
+        run: |
+          echo "Deploy to stage - $DEPLOY_STAGE"
+          echo "Deploy to prod - $DEPLOY_PROD"
+          echo "Path prefix - $PATH_PREFIX"
+          echo "Repository org - $REPO_ORG"
+          echo "Repository name - $REPO_NAME"
+          echo "Repository branch - $BRANCH_SHORT_REF"
+          echo "Base Sha - $BASE_SHA"
+          echo "Deploy All - $DEPLOY_ALL"
+          echo "Has App Secrets - $HAS_APP_SECRETS"
 
   build-auto-generated-files:
     name: Build Auto-Generated Files
@@ -150,9 +162,10 @@ jobs:
       - name: Detect identical base and HEAD SHAs
         id: check-sha-diff
         if: needs.set-state.outputs.deploy_all == 'false' && needs.set-state.outputs.base_sha != ''
+        env:
+          BASE: ${{ needs.set-state.outputs.base_sha }}
+          HEAD: ${{ steps.get-head-sha.outputs.head_sha }}
         run: |
-          BASE="${{ needs.set-state.outputs.base_sha }}"
-          HEAD="${{ steps.get-head-sha.outputs.head_sha }}"
           echo "Base SHA - $BASE"
           echo "Head SHA - $HEAD"
           if [ "$BASE" = "$HEAD" ]; then

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,14 +73,25 @@ jobs:
     if: github.repository_owner != 'AdobeDocsPrivate'
     runs-on: ubuntu-latest
     steps:
-      - run: echo "Deploy to stage - ${{ needs.set-state.outputs.deploy_stage }}"
-      - run: echo "Deploy to prod - ${{ needs.set-state.outputs.deploy_prod }}"
-      - run: echo "Path prefix - ${{ needs.set-state.outputs.path_prefix }}"
-      - run: echo "Repository org - ${{ github.event.repository.owner.login }}"
-      - run: echo "Repository name - ${{ github.event.repository.name }}"
-      - run: echo "Repository branch - ${{ needs.set-state.outputs.branch_short_ref }}"
-      - run: echo "Base Sha - ${{ needs.set-state.outputs.base_Sha }}"
-      - run: echo "Deploy All - ${{ needs.set-state.outputs.deploy_All }}"
+      - name: Echo state
+        env:
+          DEPLOY_STAGE: ${{ needs.set-state.outputs.deploy_stage }}
+          DEPLOY_PROD: ${{ needs.set-state.outputs.deploy_prod }}
+          PATH_PREFIX: ${{ needs.set-state.outputs.path_prefix }}
+          REPO_ORG: ${{ github.event.repository.owner.login }}
+          REPO_NAME: ${{ github.event.repository.name }}
+          BRANCH_SHORT_REF: ${{ needs.set-state.outputs.branch_short_ref }}
+          BASE_SHA: ${{ needs.set-state.outputs.base_Sha }}
+          DEPLOY_ALL: ${{ needs.set-state.outputs.deploy_All }}
+        run: |
+          echo "Deploy to stage - $DEPLOY_STAGE"
+          echo "Deploy to prod - $DEPLOY_PROD"
+          echo "Path prefix - $PATH_PREFIX"
+          echo "Repository org - $REPO_ORG"
+          echo "Repository name - $REPO_NAME"
+          echo "Repository branch - $BRANCH_SHORT_REF"
+          echo "Base Sha - $BASE_SHA"
+          echo "Deploy All - $DEPLOY_ALL"
 
   private-deployment-stg:
     if: github.repository_owner == 'AdobeDocsPrivate' && contains(inputs.env, 'stage')
@@ -162,13 +173,16 @@ jobs:
 
       - name: Resolve base SHA
         id: resolve-base-sha
-        run: echo "sha=${{ needs.set-state.outputs.base_Sha || steps.last-successful-deploy.outputs.base }}" >> "$GITHUB_OUTPUT"
+        env:
+          RESOLVED_SHA: ${{ needs.set-state.outputs.base_Sha || steps.last-successful-deploy.outputs.base }}
+        run: echo "sha=$RESOLVED_SHA" >> "$GITHUB_OUTPUT"
 
       - name: Detect identical base and HEAD SHAs
         id: check-sha-diff
         if: needs.set-state.outputs.deploy_All == 'false' && steps.resolve-base-sha.outputs.sha != ''
+        env:
+          BASE: ${{ steps.resolve-base-sha.outputs.sha }}
         run: |
-          BASE="${{ steps.resolve-base-sha.outputs.sha }}"
           HEAD=$(git rev-parse HEAD)
           echo "Base SHA - $BASE"
           echo "Head SHA - $HEAD"

--- a/.github/workflows/gatsby-deploy.yml
+++ b/.github/workflows/gatsby-deploy.yml
@@ -128,14 +128,25 @@ jobs:
     needs: [set-state]
     runs-on: ubuntu-latest
     steps:
-      - run: echo "Deploy to dev - ${{ needs.set-state.outputs.deploy_dev }}"
-      - run: echo "Deploy to prod - ${{ needs.set-state.outputs.deploy_prod }}"
-      - run: echo "Clean cache - ${{ needs.set-state.outputs.clean_cache }}"
-      - run: echo "Repository org - ${{ github.event.repository.owner.login }}"
-      - run: echo "Repository name - ${{ github.event.repository.name }}"
-      - run: echo "Repository branch - ${{ needs.set-state.outputs.branch_short_ref }}"
-      - run: echo "Path prefix - ${{ needs.set-state.outputs.path_prefix }}"
-      - run: echo "Exclude subfolder - ${{ needs.set-state.outputs.exclude_subfolder }}"
+      - name: Echo state
+        env:
+          DEPLOY_DEV: ${{ needs.set-state.outputs.deploy_dev }}
+          DEPLOY_PROD: ${{ needs.set-state.outputs.deploy_prod }}
+          CLEAN_CACHE: ${{ needs.set-state.outputs.clean_cache }}
+          REPO_ORG: ${{ github.event.repository.owner.login }}
+          REPO_NAME: ${{ github.event.repository.name }}
+          BRANCH_SHORT_REF: ${{ needs.set-state.outputs.branch_short_ref }}
+          PATH_PREFIX: ${{ needs.set-state.outputs.path_prefix }}
+          EXCLUDE_SUBFOLDER: ${{ needs.set-state.outputs.exclude_subfolder }}
+        run: |
+          echo "Deploy to dev - $DEPLOY_DEV"
+          echo "Deploy to prod - $DEPLOY_PROD"
+          echo "Clean cache - $CLEAN_CACHE"
+          echo "Repository org - $REPO_ORG"
+          echo "Repository name - $REPO_NAME"
+          echo "Repository branch - $BRANCH_SHORT_REF"
+          echo "Path prefix - $PATH_PREFIX"
+          echo "Exclude subfolder - $EXCLUDE_SUBFOLDER"
 
   pre-build-dev:
     needs: [set-state]

--- a/.github/workflows/private-deploy.yml
+++ b/.github/workflows/private-deploy.yml
@@ -38,15 +38,18 @@ jobs:
 
       - name: Set Matrix
         id: set-matrix
+        env:
+          REPO_OWNER: ${{ github.repository_owner }}
+          ENV_NAME: ${{ inputs.env }}
         run: |
           echo "================================================"
           echo "MATRIX PREPARATION"
           echo "================================================"
-          echo "Organization: ${{ github.repository_owner }}"
-          echo "Environment: ${{ inputs.env }}"
+          echo "Organization: $REPO_OWNER"
+          echo "Environment: $ENV_NAME"
 
           # Load the JSON data
-          matrix=$(jq --arg org "${{ github.repository_owner }}" --arg env "${{ inputs.env }}" '[.[] | select(.org == $org and .env == $env)]' _workflow-config/.github/matrix/runner_matrix.json)
+          matrix=$(jq --arg org "$REPO_OWNER" --arg env "$ENV_NAME" '[.[] | select(.org == $org and .env == $env)]' _workflow-config/.github/matrix/runner_matrix.json)
 
           # Set the formatted matrix as an output
           echo "matrix={\"include\":$(echo $matrix)}" >> $GITHUB_OUTPUT
@@ -93,13 +96,23 @@ jobs:
     strategy:
       matrix: ${{fromJson(needs.matrix_prep.outputs.matrix)}}
     steps:
-      - run: echo "Deploy to stg - ${{ needs.set-state.outputs.deploy_stg }}"
-      - run: echo "Deploy to prod - ${{ needs.set-state.outputs.deploy_prod }}"
-      - run: echo "Clean cache - ${{ needs.set-state.outputs.clean_cache }}"
-      - run: echo "Repository org - ${{ github.event.repository.owner.login }}"
-      - run: echo "Repository name - ${{ github.event.repository.name }}"
-      - run: echo "Repository branch - ${{ needs.set-state.outputs.branch_short_ref }}"
-      - run: echo "Path prefix - ${{ needs.set-state.outputs.path_prefix }}"
+      - name: Echo state
+        env:
+          DEPLOY_STG: ${{ needs.set-state.outputs.deploy_stg }}
+          DEPLOY_PROD: ${{ needs.set-state.outputs.deploy_prod }}
+          CLEAN_CACHE: ${{ needs.set-state.outputs.clean_cache }}
+          REPO_ORG: ${{ github.event.repository.owner.login }}
+          REPO_NAME: ${{ github.event.repository.name }}
+          BRANCH_SHORT_REF: ${{ needs.set-state.outputs.branch_short_ref }}
+          PATH_PREFIX: ${{ needs.set-state.outputs.path_prefix }}
+        run: |
+          echo "Deploy to stg - $DEPLOY_STG"
+          echo "Deploy to prod - $DEPLOY_PROD"
+          echo "Clean cache - $CLEAN_CACHE"
+          echo "Repository org - $REPO_ORG"
+          echo "Repository name - $REPO_NAME"
+          echo "Repository branch - $BRANCH_SHORT_REF"
+          echo "Path prefix - $PATH_PREFIX"
 
   pre-build:
     needs: [set-state, matrix_prep]
@@ -170,10 +183,12 @@ jobs:
 
       - name: Read site config
         id: config
+        env:
+          SITE_PATH_INPUT: ${{ needs.set-state.outputs.path_prefix }}
         run: |
           # Use pathPrefix from set-state job
-          SITE_PATH="${{ needs.set-state.outputs.path_prefix }}"
-          
+          SITE_PATH="$SITE_PATH_INPUT"
+
           # Strip leading and trailing slashes if present
           SITE_PATH=$(echo "$SITE_PATH" | sed 's|^/||' | sed 's|/$||')
 
@@ -500,11 +515,14 @@ jobs:
           echo "✓ Deployment to Azure completed successfully"
 
       - name: Purge Fastly Cache
+        env:
+          FASTLY_URL: ${{ needs.set-state.outputs.deploy_prod == 'true' && secrets.AIO_FASTLY_PROD_URL || secrets.AIO_FASTLY_DEV_URL }}
+          PATH_PREFIX: ${{ needs.set-state.outputs.path_prefix }}
         run: |
           echo "================================================"
           echo "PURGING FASTLY CACHE"
           echo "================================================"
-          echo "URL: ${{ needs.set-state.outputs.deploy_prod == 'true' && secrets.AIO_FASTLY_PROD_URL || secrets.AIO_FASTLY_DEV_URL }}${{ needs.set-state.outputs.path_prefix }}"
+          echo "URL: ${FASTLY_URL}${PATH_PREFIX}"
           
       - name: Purge cache
         uses: AdobeDocs/gatsby-fastly-purge-action@master

--- a/.github/workflows/upload-playground.yml
+++ b/.github/workflows/upload-playground.yml
@@ -73,12 +73,12 @@ jobs:
       - name: Collect changed markdown files
         id: files
         shell: bash
+        env:
+          BASE: ${{ github.event.before }}
+          HEAD: ${{ github.sha }}
+          TARGET_PATH: ${{ inputs.FOLDER_PATH }}
         run: |
           shopt -s globstar
-
-          BASE="${{ github.event.before }}"
-          HEAD="${{ github.sha }}"
-          TARGET_PATH="${{ inputs.FOLDER_PATH }}"
 
           if [ -z "$BASE" ] || [ "$BASE" = "0000000000000000000000000000000000000000" ]; then
             BASE="${HEAD}^"

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -27,9 +27,11 @@ jobs:
 
       - name: Check for src/pages changes
         id: filter
+        env:
+          BASE_REF: ${{ inputs.base_ref }}
         run: |
-          git fetch origin ${{ inputs.base_ref }}
-          CHANGED_FILES=$(git diff --name-only origin/${{ inputs.base_ref }}...HEAD)
+          git fetch origin "$BASE_REF"
+          CHANGED_FILES=$(git diff --name-only "origin/${BASE_REF}...HEAD")
           if echo "$CHANGED_FILES" | grep -q "^src/pages/"; then
             echo "run_validation=true" >> $GITHUB_OUTPUT
             echo "✅ Changes detected in src/pages/"
@@ -63,7 +65,9 @@ jobs:
 
       - name: Save PR number
         if: always()
-        run: echo "${{ inputs.pr_number }}" > pr-number.txt
+        env:
+          PR_NUMBER: ${{ inputs.pr_number }}
+        run: echo "$PR_NUMBER" > pr-number.txt
 
       - name: Upload linter report
         if: always()
@@ -91,20 +95,23 @@ jobs:
     if: always()
     steps:
       - name: Check validation results
+        env:
+          RUN_VALIDATION: ${{ needs.check-files.outputs.run_validation }}
+          REMARK_LINT_RESULT: ${{ needs.remark-lint.result }}
         run: |
           # No src/pages files changed — pass automatically
-          if [[ "${{ needs.check-files.outputs.run_validation }}" == "false" ]]; then
+          if [[ "$RUN_VALIDATION" == "false" ]]; then
             echo "✅ No src/pages/ files changed - validation skipped"
             exit 0
           fi
 
           # src/pages files changed — all checker jobs must have succeeded.
           # When adding a new checker job, add its result check here.
-          if [[ "${{ needs.remark-lint.result }}" == "success" ]]; then
+          if [[ "$REMARK_LINT_RESULT" == "success" ]]; then
             echo "✅ All validation checks passed"
             exit 0
           else
             echo "❌ One or more validation checks failed"
-            echo "  remark-lint: ${{ needs.remark-lint.result }}"
+            echo "  remark-lint: $REMARK_LINT_RESULT"
             exit 1
           fi


### PR DESCRIPTION
## Summary

Moves `${{ }}` context expressions out of `run:` blocks and into sibling `env:` blocks, per GitHub's [security hardening guide](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable). Flagged by security review on [commerce-php#451](https://github.com/AdobeDocs/commerce-php/pull/451/files#r3294791496).

## Ticket
https://jira.corp.adobe.com/browse/DEVSITE-2433

## Related PRs
- https://github.com/AdobeDocsPrivate/adp-devsite-workflow-private/pull/5
- https://github.com/AdobeDocs/dev-docs-template/pull/55

## Notes

GitHub substitutes `${{ }}` into the YAML *before* the shell parses it. The `env:` pattern passes the value as plain data instead, so shell metacharacters can't execute.


## Test
https://github.com/AdobeDocs/adp-devsite-github-actions-test/actions/runs/26468085998/job/77933754731

<img width="1564" height="1038" alt="Screenshot 2026-05-26 at 11 32 27 AM" src="https://github.com/user-attachments/assets/5f7061db-561f-47bc-9407-e1a09cfa61b3" />

<img width="1565" height="1047" alt="Screenshot 2026-05-26 at 11 32 15 AM" src="https://github.com/user-attachments/assets/1f02962a-48ef-4a2d-bf56-f3149189aa5b" />
