### PR TITLE
update deploy-v2 workflow

### DIFF
--- a/.github/workflows/deploy-v2.yml
+++ b/.github/workflows/deploy-v2.yml
@@ -15,6 +15,7 @@ on:
 
 jobs:
   get-base-sha:
+    if: github.repository_owner == 'AdobeDocs'
     runs-on: ubuntu-latest
     outputs:
       base_sha: ${{ steps.last-successful-deploy.outputs.base_sha }}
@@ -139,7 +140,7 @@ jobs:
       run:
         shell: bash
     needs: [set-state, build-auto-generated-files]
-    if: always()
+    if: always() && github.repository_owner == 'AdobeDocs'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Added condition check for deploy-v2 workflow to avoid forked repo triggering deployment that harm the prod env
[DEVSITE-2457](https://jira.corp.adobe.com/browse/DEVSITE-2457)

Tests:
deployment job on [test/deploy-v2-main](https://github.com/jiangy10/adp-devsite-github-actions-test/tree/refs/heads/test/deploy-v2-main): deployment was prcessedhttps://github.com/jiangy10/adp-devsite-github-actions-test/actions/runs/27294643583
deployment job on [test/deploy-v2-devsite-2457](https://github.com/jiangy10/adp-devsite-github-actions-test/tree/refs/heads/test/deploy-v2-devsite-2457): deployment was skipped because the repo author mismatch "AdobeDocs" https://github.com/jiangy10/adp-devsite-github-actions-test/actions/runs/27294626358