### PR TITLE
block the deployment to main branch only

### DIFF
--- a/.github/workflows/deploy-v2.yml
+++ b/.github/workflows/deploy-v2.yml
@@ -151,7 +151,13 @@ jobs:
       run:
         shell: bash
     needs: [set-state, build-auto-generated-files]
-    if: always()
+    # Run when set-state succeeded (which transitively requires validate-prod-branch to pass)
+    # and build-auto-generated-files either succeeded or was skipped (no-app-secrets repos).
+    # Using always() here would let deploy proceed even when an upstream gate fails.
+    if: |
+      always() &&
+      needs.set-state.result == 'success' &&
+      (needs.build-auto-generated-files.result == 'success' || needs.build-auto-generated-files.result == 'skipped')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/deploy-v2.yml
+++ b/.github/workflows/deploy-v2.yml
@@ -14,7 +14,19 @@ on:
         default: false
 
 jobs:
+  validate-prod-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Reject prod deployment from non-main branch
+        if: contains(inputs.env, 'prod') && github.ref != 'refs/heads/main'
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const branch = context.ref.replace('refs/heads/', '');
+            core.setFailed(`Production deployment is only allowed from the 'main' branch. Current branch: '${branch}'. Please merge to 'main' and re-run, or select 'stage' as the environment.`);
+
   get-base-sha:
+    needs: [validate-prod-branch]
     runs-on: ubuntu-latest
     outputs:
       base_sha: ${{ steps.last-successful-deploy.outputs.base_sha }}

--- a/.github/workflows/deploy-v2.yml
+++ b/.github/workflows/deploy-v2.yml
@@ -151,9 +151,6 @@ jobs:
       run:
         shell: bash
     needs: [set-state, build-auto-generated-files]
-    # Run when set-state succeeded (which transitively requires validate-prod-branch to pass)
-    # and build-auto-generated-files either succeeded or was skipped (no-app-secrets repos).
-    # Using always() here would let deploy proceed even when an upstream gate fails.
     if: |
       always() &&
       needs.set-state.result == 'success' &&

--- a/.github/workflows/deploy-v2.yml
+++ b/.github/workflows/deploy-v2.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           script: |
             const branch = context.ref.replace('refs/heads/', '');
-            core.setFailed(`Production deployment is only allowed from the 'main' branch. Current branch: '${branch}'. Please merge to 'main' and re-run, or select 'stage' as the environment.`);
+            core.setFailed(`Production deployment is only allowed from the 'main' branch. Current branch: '${branch}'. Please merge to 'main' and re-run, or use the Staging workflow to deploy a non-main branch.`);
 
   get-base-sha:
     needs: [validate-prod-branch]


### PR DESCRIPTION
We are trying to lock the deployment to main branch only.  If the workflow is called from any other branches, it will failed to deploy.
Calling the workflow from test public repo from a non-main branch:
https://github.com/AdobeDocs/adp-devsite-github-actions-test/actions/runs/27242153493
<img width="1623" height="856" alt="Screenshot 2026-06-09 at 4 20 14 PM" src="https://github.com/user-attachments/assets/d248746a-4df3-455b-899a-8b667052334e" />

Calling the workflow from a test private repo from a non-main branch: 
https://github.com/AdobeDocsPrivate/adp-dev-docs-private/actions/runs/27242881239
<img width="1718" height="955" alt="Screenshot 2026-06-09 at 4 38 21 PM" src="https://github.com/user-attachments/assets/efb00f25-0a5a-4b90-8d53-1eee469b4021" />
