### PR TITLE
Fix the deploy workflow to only allow main to deploy

### DIFF
--- a/.github/workflows/deploy-v2.yml
+++ b/.github/workflows/deploy-v2.yml
@@ -155,7 +155,7 @@ jobs:
     if: |
       always() &&
       github.repository_owner == 'AdobeDocs' &&
-      needs.set-state.result == 'success' &&
+      needs.set-state.result == 'success'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/deploy-v2.yml
+++ b/.github/workflows/deploy-v2.yml
@@ -14,7 +14,19 @@ on:
         default: false
 
 jobs:
+  validate-prod-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Reject prod deployment from non-main branch
+        if: contains(inputs.env, 'prod') && github.ref != 'refs/heads/main'
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const branch = context.ref.replace('refs/heads/', '');
+            core.setFailed(`Production deployment is only allowed from the 'main' branch. Current branch: '${branch}'. Please merge to 'main' and re-run, or use the Staging workflow to deploy a non-main branch.`);
+
   get-base-sha:
+    needs: [validate-prod-branch]
     if: github.repository_owner == 'AdobeDocs'
     runs-on: ubuntu-latest
     outputs:
@@ -140,7 +152,10 @@ jobs:
       run:
         shell: bash
     needs: [set-state, build-auto-generated-files]
-    if: always() && github.repository_owner == 'AdobeDocs'
+    if: |
+      always() &&
+      github.repository_owner == 'AdobeDocs' &&
+      needs.set-state.result == 'success' &&
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
We are trying to lock the deployment to main branch only. If the workflow is called from any other branches, it will failed to deploy.
Calling the workflow from test public repo from a non-main branch:
https://github.com/AdobeDocs/adp-devsite-github-actions-test/actions/runs/27242153493
<img width="1693" height="852" alt="Screenshot 2026-06-11 at 1 14 00 PM" src="https://github.com/user-attachments/assets/4e12308e-cd4c-4a39-98a6-d7f48b583976" />
