### PR TITLE
Devsite 2480 - Skip linter check for deleted file (v3 workflow only)

### DIFF
--- a/.github/workflows/lint-v3.yml
+++ b/.github/workflows/lint-v3.yml
@@ -35,7 +35,7 @@ jobs:
           BASE_REF: ${{ inputs.base_ref }}
         run: |
           git fetch origin "$BASE_REF"
-          CHANGED_FILES=$(git diff --name-only "origin/${BASE_REF}...HEAD")
+          CHANGED_FILES=$(git diff --diff-filter=d --name-only "origin/${BASE_REF}...HEAD")
           if echo "$CHANGED_FILES" | grep -q "^src/pages/"; then
             echo "run_lint=true" >> $GITHUB_OUTPUT
             echo "✅ Changes detected in src/pages/"

--- a/.github/workflows/lint-v3.yml
+++ b/.github/workflows/lint-v3.yml
@@ -63,7 +63,7 @@ jobs:
         env:
           BASE_REF: ${{ inputs.base_ref }}
         run: |
-          CHANGED_MD=$(git diff --name-only "origin/${BASE_REF}...HEAD" | grep "^src/pages/.*\.md$" | tr '\n' ' ')
+          CHANGED_MD=$(git diff --diff-filter=d --name-only "origin/${BASE_REF}...HEAD" | grep "^src/pages/.*\.md$" | tr '\n' ' ')
           npx --yes github:AdobeDocs/adp-devsite-utils#DEVSITE-2442 runLint -v $CHANGED_MD
 
       - name: Save PR number

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -58,28 +58,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Get changed non-deleted markdown files
-        id: changed-files
-        env:
-          BASE_REF: ${{ inputs.base_ref }}
-        run: |
-          git fetch origin "$BASE_REF"
-          FILES=$(git diff --diff-filter=d --name-only "origin/${BASE_REF}...HEAD" \
-            | grep '^src/pages/.*\.md$' || true)
-          echo "files<<EOF" >> $GITHUB_OUTPUT
-          echo "$FILES" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
-
       - name: Lint
         id: lint
         continue-on-error: true
-        run: |
-          FILES="${{ steps.changed-files.outputs.files }}"
-          if [ -z "$FILES" ]; then
-            echo "No markdown files to lint"
-            exit 0
-          fi
-          npx --yes github:AdobeDocs/adp-devsite-utils runLint -v $FILES
+        run: npx --yes github:AdobeDocs/adp-devsite-utils runLint -v
 
       - name: Save PR number
         if: always()

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -58,10 +58,28 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Get changed non-deleted markdown files
+        id: changed-files
+        env:
+          BASE_REF: ${{ inputs.base_ref }}
+        run: |
+          git fetch origin "$BASE_REF"
+          FILES=$(git diff --diff-filter=d --name-only "origin/${BASE_REF}...HEAD" \
+            | grep '^src/pages/.*\.md$' || true)
+          echo "files<<EOF" >> $GITHUB_OUTPUT
+          echo "$FILES" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
       - name: Lint
         id: lint
         continue-on-error: true
-        run: npx --yes github:AdobeDocs/adp-devsite-utils runLint -v
+        run: |
+          FILES="${{ steps.changed-files.outputs.files }}"
+          if [ -z "$FILES" ]; then
+            echo "No markdown files to lint"
+            exit 0
+          fi
+          npx --yes github:AdobeDocs/adp-devsite-utils runLint -v $FILES
 
       - name: Save PR number
         if: always()


### PR DESCRIPTION
JIRA: [DEVSITE-2480](https://jira.corp.adobe.com/browse/DEVSITE-2480)

From Dima's feedback, pr-valiation will checkout all changed md files in the PR and run the linter for them. But the deleted files should not go through the linter, so added a skipper in the workflow.

Test :https://github.com/AdobeDocs/adp-devsite-github-actions-test/pull/154
Two files are modified, but only one went through the linter
<img width="436" height="189" alt="image" src="https://github.com/user-attachments/assets/1eb3083b-b5fd-47ff-be2a-281b1068f4d4" />
<img width="894" height="794" alt="image" src="https://github.com/user-attachments/assets/e335ba02-19d3-4ba3-b59f-79bd6b3be9c4" />
