### PR TITLE
fixing devsite-2482

### DIFF
--- a/.github/workflows/build-contributors-v2.yml
+++ b/.github/workflows/build-contributors-v2.yml
@@ -32,7 +32,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.ADP_DEVSITE_APP_ID }}
+          client-id: ${{ secrets.ADP_DEVSITE_APP_ID }}
           private-key: ${{ secrets.ADP_DEVSITE_APP_PRIVATE_KEY }}
 
       - name: Build Contributors

--- a/.github/workflows/build-site-metadata-v2.yml
+++ b/.github/workflows/build-site-metadata-v2.yml
@@ -23,7 +23,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.ADP_DEVSITE_APP_ID }}
+          client-id: ${{ secrets.ADP_DEVSITE_APP_ID }}
           private-key: ${{ secrets.ADP_DEVSITE_APP_PRIVATE_KEY }}
 
       - name: Build Site Metadata


### PR DESCRIPTION
Based on this ticket:
https://jira.corp.adobe.com/browse/DEVSITE-2482
Need to change the app-id to client-id on both build-contributors-v2.yml and build-site-metadata-v2.yml

Tested on adp-devsite-github-action-test 
https://github.com/AdobeDocs/adp-devsite-github-actions-test/actions/runs/31440285025
Now there is no more annotation warning. 
