### PR TITLE
fix: avoid startup failure for consumers with read-only default tokens

### DIFF
--- a/.github/workflows/build-contributors-v2.yml
+++ b/.github/workflows/build-contributors-v2.yml
@@ -15,7 +15,7 @@ jobs:
   build-contributors:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/build-site-metadata-v2.yml
+++ b/.github/workflows/build-site-metadata-v2.yml
@@ -7,7 +7,7 @@ jobs:
   build-site-metadata:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
## Issue
`build-contributors-v2.yml` and `build-site-metadata-v2.yml` declared contents: write, a leftover from v1 that's no longer needed since both push using a GitHub App token, not `GITHUB_TOKEN`. Because reusable-workflow permissions can't be elevated through the chain, consuming repos with read-only default tokens failed startup validation before any job ran.

## Workaround (until merged)
Content repos hitting the startup failure need `contents: write` set in their own workflow permissions in the meantime.

<img width="928" height="290" alt="Screenshot 2026-08-21 at 3 22 29 PM" src="https://github.com/user-attachments/assets/8086ee69-1bb7-4ea3-acb1-26e1e59bd336" />

Once this merges, they can set it back to `read`.

<img width="979" height="384" alt="Screenshot 2026-08-21 at 3 20 51 PM" src="https://github.com/user-attachments/assets/687c59f9-ff63-4af3-8d54-252e0519e4f6" />

## Fix
Downgrade both to `contents: read`, matching what they actually use.

## Ticket
https://jira.corp.adobe.com/browse/DEVSITE-2508

## Before
https://github.com/AdobeDocs/adp-devsite-github-actions-test/actions/runs/32529229374

<img width="1507" height="1091" alt="Screenshot 2026-08-21 at 2 35 57 PM" src="https://github.com/user-attachments/assets/26a2ca9c-3863-4b43-8ab1-95ea4f2599aa" />

## After
https://github.com/AdobeDocs/adp-devsite-github-actions-test/actions/runs/32529327790


<img width="1507" height="1090" alt="Screenshot 2026-08-21 at 2 40 59 PM" src="https://github.com/user-attachments/assets/bd43fee6-227b-438b-9e7b-7267a1c9d408" />


