### PR TITLE
fix: scope git pull to current branch in reusable deploy/build workflows

### DIFF
--- a/.github/workflows/build-contributors-v2.yml
+++ b/.github/workflows/build-contributors-v2.yml
@@ -51,6 +51,6 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${REPO}"
           git add src/pages/contributors.json
-          git pull
+          git pull origin "${GITHUB_REF#refs/heads/}" --ff-only
           git diff --cached --quiet || git commit -m "chore: auto-generate contributors"
           git push

--- a/.github/workflows/build-site-metadata-v2.yml
+++ b/.github/workflows/build-site-metadata-v2.yml
@@ -38,6 +38,6 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${REPO}"
           git add src/pages/adp-site-metadata.json
-          git pull
+          git pull origin "${GITHUB_REF#refs/heads/}" --ff-only
           git diff --cached --quiet || git commit -m "chore: auto-generate site metadata"
           git push

--- a/.github/workflows/deploy-v2.yml
+++ b/.github/workflows/deploy-v2.yml
@@ -174,7 +174,9 @@ jobs:
           node-version: "lts/krypton"
 
       - name: Pull auto-generated file commits
-        run: git pull
+        env:
+          BRANCH: ${{ needs.set-state.outputs.branch_short_ref }}
+        run: git pull origin "$BRANCH" --ff-only
 
       - name: Get head SHA
         id: get-head-sha


### PR DESCRIPTION
## Description

The `deploy` job's "Pull auto-generated file commits" step ran a bare `git pull`, which uses the default wildcard refspec and fetches **every branch** in the repo when it only needs to fast-forward the current branch. On a shallow checkout this forces expensive history-deepening negotiation — on a repo with ~80 branches this added minutes to a step that should take seconds.

Each `git pull` is now scoped to the current branch, with two safety properties:

- The branch name is passed via `env:` and referenced as a shell variable, not interpolated directly into the `run:` script. Branch names can legally contain shell metacharacters (`$(...)`, unescaped `"`), so this avoids command injection — consistent with how `GH_TOKEN`, `REPO`, `BASE`, `HEAD` are already handled in these workflows.
- Each pull uses `--ff-only`. These pulls only fast-forward onto commits pushed earlier in the same run, so a fast-forward should always be possible; `--ff-only` fails loudly instead of silently creating a merge commit if that's ever wrong.

Pull results are unchanged in the normal case.


## Ticket
https://jira.corp.adobe.com/browse/DEVSITE-2546

## Test
Verified on `adp-devsite-github-actions-test` (~80 branches). Before, each bare `git pull` fetched every branch via the default wildcard refspec; after, it fetches only the current branch.

| Job — step | Before | After |
|---|---|---|
| **build-site-metadata** — "Commit and push if changed" | **5m 29s**, ~80 `[new branch]` <br> <img width="1195" height="1089" alt="before metadata" src="https://github.com/user-attachments/assets/8b2ddd34-9a73-44ae-b770-099c4d6ec26e" /> | **23s**, single branch <br> <img width="1192" height="1093" alt="after metadata" src="https://github.com/user-attachments/assets/f403cb68-fdc7-461f-8e33-c255873bc6d3" /> |
| **deploy** — "Pull auto-generated file commits" | **3m 32s**, ~80 `[new branch]` <br> <img width="1194" height="1091" alt="before deploy" src="https://github.com/user-attachments/assets/deba86a4-2e8c-48fb-b4cc-254fbbed9256" /> | **45s**, single branch <br> <img width="1195" height="1090" alt="after deploy" src="https://github.com/user-attachments/assets/b96ad63f-4518-4dc4-8bec-201d4fd32a3f" /> |

_build-contributors uses full-history checkout, so it was already fast — same fix applied for consistency._

Ran `stage.yml` end-to-end and confirmed all three jobs still pull/commit/push successfully.

